### PR TITLE
fix(VariableTable): use correct tooltip

### DIFF
--- a/lib/Components/VariableTable/VariableTable.jsx
+++ b/lib/Components/VariableTable/VariableTable.jsx
@@ -53,7 +53,7 @@ function Variables(
 
 
   return <div className="bio-vo-variable-table">
-    <Tooltip align="bottom-start" label="Elements that create or write variables">
+    <Tooltip align="bottom-start" label="Variables associated with the currently selected element">
       <div className="bio-vo-label bio-vo-tooltip-wrapper">Variables</div>
     </Tooltip>
     <DataTable rows={ rows } headers={ HEADERS } isSortable sortRow={ customSort }>


### PR DESCRIPTION
### Proposed Changes
@lmbateman noticed that the Tooltips for elements and Variables are the same. This PR adds the correct tooltip text from the [figma sketch](https://www.figma.com/design/XPTZB5YNWTcQFmqCDfIshH/Variable-Management-UI?node-id=1-56291&t=TVsdctpfSSuuTWt7-4) 

![image](https://github.com/user-attachments/assets/e46e056d-d1b4-4053-9cf0-693fa49ceb54)

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
