### PR TITLE
fix: element tab tooltip cutoff

### DIFF
--- a/lib/Components/ElementList/ElementList.scss
+++ b/lib/Components/ElementList/ElementList.scss
@@ -12,5 +12,14 @@
 
   .cds--popover--bottom-start .cds--popover-content {
     margin-left: calc(1.5 * var(--cds-popover-offset, 0px));
+    inline-size: auto;
+  }
+  
+  .cds--popover-container {
+    width: 100%;
+  }
+
+  .cds--popover--bottom-start > .cds--popover > .cds--popover-caret {
+    inset-inline-start: 15%;
   }
 }


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
![Sep-09-2024 00-55-23](https://github.com/user-attachments/assets/287e242c-6906-41ef-89ad-ca6c505f7e15)

--> 

Fixed Element tab tooltip cutting off 
![Sep-09-2024 00-55-23](https://github.com/user-attachments/assets/287e242c-6906-41ef-89ad-ca6c505f7e15)

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->

Related to: https://github.com/camunda/camunda-modeler/issues/4496
