### PR TITLE
fix: larger names shrunk in variable tab

### DIFF
--- a/lib/Components/ElementList/ElementList.jsx
+++ b/lib/Components/ElementList/ElementList.jsx
@@ -127,7 +127,9 @@ function ElementEntry(props) {
         value={ bo.id }
         renderIcon={ icon }
         label={
-          bo.name || bo.label || bo.id
+          <span className="tree-node-elements">
+            {bo.name || bo.label || bo.id}
+          </span>
         }
         onSelect={ handleSelect }
         selected={ isSelected ? [ bo.id ] : [] }

--- a/lib/Components/ElementList/ElementList.scss
+++ b/lib/Components/ElementList/ElementList.scss
@@ -13,4 +13,21 @@
   .cds--popover--bottom-start .cds--popover-content {
     margin-left: calc(1.5 * var(--cds-popover-offset, 0px));
   }
+
+
+.tree-node-elements, .cds--tree-node__label__details {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  }
+
+.cds--tree-leaf-node {
+  display: inherit; 
+  }
+
+.cds--tree-node__label svg {
+  flex-shrink: 0;
+  }
+
 }


### PR DESCRIPTION
Related to: https://github.com/camunda/camunda-modeler/issues/4505

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

Truncate variable names exceeding max width with ellipses for improved readability
<img width="822" alt="Screenshot 2024-11-06 at 15 13 56" src="https://github.com/user-attachments/assets/e9e6eb78-528c-4a02-a104-347339a66a95">

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
