### PR TITLE
chore: exclude carbon styles from Variable Outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the [@bpmn-io/variable-outline](https://github.com/bpmn-i
 
 ## Unreleased
 
+## 2.0.0
+
+* `CHORE`: remove explicit carbon styles, to be provided by the infrastructure ([#8](https://github.com/bpmn-io/variable-outline/pull/8))
+
+### Breaking Changes
+* This release no longer ships with Carbon styles.
+
 ## 1.0.4
 
 * `FIX`: added focus indicators for table elements ([#6](https://github.com/bpmn-io/variable-outline/pull/6))

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ export function MyComponent(props) {
 }
 ```
 
+### Using Carbon Styles
+
+Note: This library does not include @carbon/react styles. If you need them, you must import them into your existing SCSS file:
+
+```scss
+@use '@carbon/react/scss/zone';
+@use '@carbon/react/scss/reset';
+```
+
 ## Development
 
 Start a demo page with `npm run start`.

--- a/example/index.scss
+++ b/example/index.scss
@@ -1,3 +1,5 @@
+@use '@carbon/react/scss/zone';
+@use '@carbon/react/scss/reset';
 
 body {
   margin: 0;

--- a/example/main.jsx
+++ b/example/main.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
-import './index.css';
+import './index.scss';
 
 // eslint-disable-next-line no-undef
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/lib/style.scss
+++ b/lib/style.scss
@@ -1,7 +1,3 @@
-// Allow styling using carbon themes
-@use '@carbon/react/scss/zone';
-@use '@carbon/react/scss/reset';
-
 .bio-vo-tab-content {
   height: 100%;
   max-height: 100%;


### PR DESCRIPTION
Related to camunda-modeler: [#4511](https://github.com/camunda/camunda-modeler/issues/4511)
### Proposed Changes

- Removed carbon theme styling from lib.
- added styles in example, so standalone lib example works the same

No visual demo since it works the same, just some changes behind the hood
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Steps to try out
1. Run the project `npm start`

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
