### PR TITLE
fix: explicitly handle first two origins

### DIFF
--- a/lib/Components/VariableTable/Origin.jsx
+++ b/lib/Components/VariableTable/Origin.jsx
@@ -6,15 +6,18 @@ import './Origin.scss';
 export default function Origin(props) {
   const { origins } = props;
 
-  const firstTwoOrigins = origins.slice(0, 2);
+  const [ firstOrigin, secondOrigin ] = origins.slice(0, 2);
   const additionalOrigins = origins.length - 2;
 
   return <div className="bio-vo-origin">
     {
-      firstTwoOrigins
-        .map((origin, index) => <>
-          { index ? ' | ' : null } <Element key={ origin.id } element={ origin } />
-        </>)
+      <Element element={ firstOrigin } />
+    }
+    {
+      secondOrigin ? <>
+        { ' | ' }
+        <Element element={ secondOrigin } />
+      </> : null
     }
     {additionalOrigins > 0 && <Tag type="gray">{`+${additionalOrigins}`}</Tag>}
   </div>;


### PR DESCRIPTION
### Proposed Changes

This makes sure that React does not complain about missing unique key for singleton lists. It's a workaround but allows to avoid error in Desktop Modeler. No warnings are printed with the change:

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/4ce549ff-2b35-4b77-8540-d9a69db14437" />

Related to https://github.com/camunda/camunda-modeler/issues/4940

Once this is merged, I will port it to 1.x branch.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
