### PR TITLE
Exclude carbon styles 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,11 @@ export function MyComponent(props) {
 ```
 
 ### Using Carbon Styles
-
-Note: This library does not include @carbon/react styles. If you need them, you must import them into your existing SCSS file:
+> [!NOTE]  
+> This library does not include `@carbon` styles. If you need them, you must import them into your existing SCSS file:
 
 ```scss
-@use '@carbon/react/scss/zone';
-@use '@carbon/react/scss/reset';
+@use '@carbon/styles';
 ```
 
 ## Development

--- a/example/index.scss
+++ b/example/index.scss
@@ -1,5 +1,4 @@
-@use '@carbon/react/scss/zone';
-@use '@carbon/react/scss/reset';
+@use '@carbon/styles';
 
 body {
   margin: 0;

--- a/lib/Components/ElementList/ElementList.scss
+++ b/lib/Components/ElementList/ElementList.scss
@@ -1,5 +1,3 @@
-@use '@carbon/react/scss/components/treeview';
-
 .bio-vo-element-list {
 
   // prevent text selection on shift-click

--- a/lib/Components/Search/Search.scss
+++ b/lib/Components/Search/Search.scss
@@ -1,6 +1,3 @@
-@use '@carbon/react/scss/components/search';
-@use '@carbon/react/scss/components/checkbox';
-
 .bio-vo-tab-content .bio-vo-search-container {
   line-height: 1;
 

--- a/lib/Components/VariableTable/VariableTable.scss
+++ b/lib/Components/VariableTable/VariableTable.scss
@@ -1,8 +1,3 @@
-@use '@carbon/react/scss/components/tooltip';
-@use '@carbon/react/scss/components/data-table';
-@use '@carbon/react/scss/components/data-table/sort';
-
-
 .bio-vo-variable-table {
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;


### PR DESCRIPTION
Related to camunda-modeler: https://github.com/camunda/camunda-modeler/issues/4511
Supersedes #8 
### Proposed Changes

- `@carbon/styles` are used in the example project.
![image](https://github.com/user-attachments/assets/9747ed2f-4eeb-4173-b3f0-0c97f2e0f2c8)

Our goal is to provide variable-outline features and components only, without styles.
without `@carbon/styles` in the example project. 

![image](https://github.com/user-attachments/assets/d97626c2-399d-43ca-816a-d21e4fdf8bc3)

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 


### Steps to try out 
1. run `npm run build`
2. See the dist/styles file. Note that it should only contain user defined styles and not carbon default styles

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
