### PR TITLE
chore: ensure `start` opens the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/variable-outline.mjs",
   "scripts": {
     "all": "run-s lint test build",
-    "start": "vite --config demo.config.mjs",
+    "start": "vite --config demo.config.mjs --open",
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest watch",


### PR DESCRIPTION
### Proposed Changes

As per our foundations, `npm start` spins up an example, and _opens it in the browser_.

This is what this PR fixes.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
