### PR TITLE
fix: name css filename as style

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -16,7 +16,8 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'lib/index.jsx'),
-      formats: [ 'es' ]
+      formats: [ 'es' ],
+      cssFileName: 'style'
     },
     rollupOptions: {
       external: [ ...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies) ],


### PR DESCRIPTION
### Proposed Changes

After upgrading toolchain deps today, the behavior of building CSS file has changed and thus, broke the distribution.

It was previously generated as `dist/style.css` which now is `dist/variable-outline.css`. Since we are using it with `dist/style.css` in upstream, I have introduced the `build.lib.cssFileName` vite config property to name it again as `dist/style.css`. 

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
