### PR TITLE
fix: truncate long variable name

### DIFF
--- a/lib/Components/outline-variables.scss
+++ b/lib/Components/outline-variables.scss
@@ -233,7 +233,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  flex-shrink: 0;
+  flex-shrink: 1;
   min-width: 0;
 }
 


### PR DESCRIPTION
### Proposed Changes

The long variable name was causing a horizontal overflow and hence, the scroll and broken UI. With these changes, the variable name should be truncated properly. 

<img width="379" height="349" alt="image" src="https://github.com/user-attachments/assets/0c07cc08-6e57-47ec-8e28-30bca2d0223d" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
