### PR TITLE
fix: add border-box box-sizing in scope header

### DIFF
--- a/lib/components/outline-variables.scss
+++ b/lib/components/outline-variables.scss
@@ -29,6 +29,7 @@
   all: unset;
   width: 100%;
   position: sticky;
+  box-sizing: border-box;
   top: 0;
   z-index: 2;
   display: flex;


### PR DESCRIPTION
### Proposed Changes

Fixes the box-sizing which is overridden by `all: unset` so that it does not overflow and introduce a horizontal scroll.

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
