### PR TITLE
fix: auto align tooltip not to overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: add written by selection filter ([#21](https://github.com/bpmn-io/variable-outline/pull/21))
 * `FEAT`: show variable value with codemirror ([#24](https://github.com/bpmn-io/variable-outline/pull/24))
 * `FEAT`: add collapse/expand scope groups functionality ([#22](https://github.com/bpmn-io/variable-outline/pull/22))
+* `FIX`: auto align tooltip not to overflow ([#49](https://github.com/bpmn-io/variable-outline/pull/49))
 
 ## 2.0.1
 

--- a/lib/components/Search/Search.jsx
+++ b/lib/components/Search/Search.jsx
@@ -28,6 +28,7 @@ export default function Search() {
       className="bio-vo-help"
       label="This panel shows the variables accessible to the selected element, grouped by scope. Expand a variable to see which elements write it and what value it holds. Use the search or filters to narrow down the list."
       align="bottom-end"
+      autoAlign
     >
       <Help />
     </Tooltip>


### PR DESCRIPTION
### Proposed Changes

This pull request aims to fix overflowing tooltip by auto aligning it.

<img width="1576" height="970" alt="image" src="https://github.com/user-attachments/assets/3f1f7031-cb8c-49e4-866c-2a4e0011ce32" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
