### PR TITLE
fix: remove isolation to fix clipped tooltip

### DIFF
--- a/lib/components/outline-variables.scss
+++ b/lib/components/outline-variables.scss
@@ -10,7 +10,6 @@
   bottom: 0;
   left: 0;
   overflow-y: auto;
-  isolation: isolate;
 }
 
 .variable-scope-group {


### PR DESCRIPTION
Related to camunda/camunda-modeler#5727

### Proposed Changes

This pull request aims to prevent the tooltip(s) from being clipped.

The `isolation` was initially introduced to prevent the sticky (scope group) headers being under scrolling elements. However, as the library went through a refactor, the problem seems naturally eliminated. So, we do not need the isolation anymore as much as I have tested the sticky header functionality along with this change.

<img width="783" height="334" alt="image" src="https://github.com/user-attachments/assets/b3bd9d32-a20b-4a66-8fea-e45d01a651b2" />

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
