### PR TITLE
fix: prevent variable name from overflowing

### DIFF
--- a/lib/components/VariableRow/VariableRow.jsx
+++ b/lib/components/VariableRow/VariableRow.jsx
@@ -30,9 +30,8 @@ export default function VariableRow({ variable, isSelectedOrigin, expanded, onTo
           <ChevronRight className={ `variable-row-chevron${expanded ? ' variable-row-chevron--expanded' : ''}` } />
           <div className="variable-row-content">
             <div className="variable-row-info">
-              <Tooltip label={ variable.name } align="bottom" enterDelayMs={ 500 } autoAlign>
-                <span className="variable-name">{ variable.name }</span>
-              </Tooltip>
+              <span className="variable-name">{ variable.name }</span>
+
               { isSelectedOrigin && (
                 <Tooltip label="This variable is written by current selection." align="bottom" autoAlign>
                   <span className="variable-written-tag">

--- a/lib/components/outline-variables.scss
+++ b/lib/components/outline-variables.scss
@@ -191,11 +191,6 @@
   align-items: center;
   gap: 6px;
   min-width: 0;
-
-  > .cds--tooltip {
-    flex-shrink: 1;
-    min-width: 0;
-  }
 }
 
 .variable-row-details {


### PR DESCRIPTION
### Proposed Changes

This pull request aims to prevent variable name from overflowing and show a tooltip for the variable name upon 500ms visit on the name. Cf. [internal feedback on Slack](https://camunda.slack.com/archives/C09QG3ZDRKJ/p1773313945294129?thread_ts=1773225089.509619&cid=C09QG3ZDRKJ)

<img width="460" height="205" alt="image" src="https://github.com/user-attachments/assets/ebc5e60a-1b7e-44f2-8b84-e6d98d8dccb6" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
