### PR TITLE
fix: make section header height deterministic for correct sticky positioning

### DIFF
--- a/lib/components/outline-variables.scss
+++ b/lib/components/outline-variables.scss
@@ -36,6 +36,7 @@
   gap: 6px;
   padding: 10px 12px;
   font-size: 14px;
+  line-height: 20px;
   font-weight: 500;
   user-select: none;
   cursor: pointer;
@@ -143,7 +144,7 @@
 
   .variable-row--expanded & {
     position: sticky;
-    top: 46px;
+    top: 40px;
     z-index: 1;
     border-bottom: none;
   }


### PR DESCRIPTION
### Proposed Changes

The pull request aims to make the sticky header height deterministic so that the sticky headers are properly aligned in y-axis below each other in both variable-outline example and upstreams.

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
