### PR TITLE
feat: vertically center empty state and add learn more link

### DIFF
--- a/lib/components/EmptyState/EmptyState.jsx
+++ b/lib/components/EmptyState/EmptyState.jsx
@@ -1,16 +1,30 @@
+import { Link } from '@carbon/react';
+
 import './EmptyState.scss';
+import EmptyStateIcon from '../BpmnIcon/svg/bpmn-empty-state.svg?react';
 
-export default function EmptyState({ rawVariables }) {
+export default function EmptyState({ rawVariables, learnMoreUrl }) {
 
-  const TITLE = rawVariables.length ? 'No matching Variables' : 'No Process Variables';
-  const DESCRIPTION = rawVariables.length ? 'Check your query or select a different scope.' : 'Add Variables to your process through mappings, forms or example data.';
+  const TITLE = rawVariables.length ? 'No matching variables' : 'No process variables';
+  const DESCRIPTION = rawVariables.length ? 'Check your query or select a different element.' : 'Add variables to your process through mappings, forms or example data.';
 
   return (
-    <div className="bio-vo-empty-search">
-      <h3>{TITLE}</h3>
-      <p>
+    <div className="bio-vo-empty-state">
+      <EmptyStateIcon className="bio-vo-empty-state__icon" aria-hidden="true" focusable="false" />
+      <h3 className="bio-vo-empty-state__title">{TITLE}</h3>
+      <p className="bio-vo-empty-state__description">
         {DESCRIPTION}
       </p>
+      {learnMoreUrl && (
+        <Link
+          href={ learnMoreUrl }
+          target="_blank"
+          rel="noopener noreferrer"
+          className="bio-vo-empty-state__link"
+        >
+          Learn more
+        </Link>
+      )}
     </div>
   );
 }

--- a/lib/components/EmptyState/EmptyState.scss
+++ b/lib/components/EmptyState/EmptyState.scss
@@ -1,7 +1,29 @@
-.bio-vo-empty-search {
-  margin: 30px;
-  padding: 2rem;
-  h3 {
-    margin-bottom: 2rem;
+.bio-vo-empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: var(--cds-text-secondary, #525252);
+  font-size: var(--text-size-base);
+
+  &__icon {
+    margin-bottom: 8px;
+  }
+
+  &__title {
+    font-size: var(--text-size-base);
+    font-weight: 600;
+    margin: 0 0 4px 0;
+  }
+
+  &__description {
+    margin: 0 48px;
+    font-weight: 400;
+  }
+
+  &__link {
+    margin-top: 8px;
   }
 }

--- a/lib/components/EmptyState/__test__/EmptyState.spec.jsx
+++ b/lib/components/EmptyState/__test__/EmptyState.spec.jsx
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+
+import EmptyState from '../EmptyState';
+
+
+describe('lib/components/EmptyState', () => {
+
+  describe('no process variables', () => {
+
+    it('should render empty state icon', () => {
+
+      // when
+      const { container } = render(<EmptyState rawVariables={ [] } />);
+
+      // then
+      expect(container.querySelector('svg')).to.exist;
+    });
+
+
+    it('should render title', () => {
+
+      // when
+      const { getByRole } = render(<EmptyState rawVariables={ [] } />);
+
+      // then
+      expect(getByRole('heading', { name: 'No process variables' })).to.exist;
+    });
+
+
+    it('should render description', () => {
+
+      // when
+      const { getByText } = render(<EmptyState rawVariables={ [] } />);
+
+      // then
+      expect(getByText('Add variables to your process through mappings, forms or example data.')).to.exist;
+    });
+
+  });
+
+
+  describe('no matching variables', () => {
+
+    it('should render empty state icon', () => {
+
+      // when
+      const { container } = render(<EmptyState rawVariables={ [ { name: 'foo' } ] } />);
+
+      // then
+      expect(container.querySelector('svg')).to.exist;
+    });
+
+
+    it('should render title', () => {
+
+      // when
+      const { getByRole } = render(<EmptyState rawVariables={ [ { name: 'foo' } ] } />);
+
+      // then
+      expect(getByRole('heading', { name: 'No matching variables' })).to.exist;
+    });
+
+
+    it('should render description', () => {
+
+      // when
+      const { getByText } = render(<EmptyState rawVariables={ [ { name: 'foo' } ] } />);
+
+      // then
+      expect(getByText('Check your query or select a different element.')).to.exist;
+    });
+
+  });
+
+
+  describe('learn more link', () => {
+
+    it('should render link when learnMoreUrl is provided', () => {
+
+      // when
+      const { getByRole } = render(
+        <EmptyState rawVariables={ [] } learnMoreUrl="https://docs.example.com" />
+      );
+
+      // then
+      const link = getByRole('link', { name: 'Learn more' });
+      expect(link).to.exist;
+      expect(link.getAttribute('href')).to.eql('https://docs.example.com');
+      expect(link.getAttribute('target')).to.eql('_blank');
+    });
+
+
+    it('should not render link when learnMoreUrl is not provided', () => {
+
+      // when
+      const { queryByRole } = render(<EmptyState rawVariables={ [] } />);
+
+      // then
+      expect(queryByRole('link')).to.not.exist;
+    });
+
+  });
+
+});

--- a/lib/components/TabContent.jsx
+++ b/lib/components/TabContent.jsx
@@ -10,13 +10,14 @@ import Search from './Search';
 
 export default function TabContent(props) {
   const { rawVariables, availableVariables } = useVariables();
+  const { learnMoreUrl } = props;
 
   return <div className="bio-vo-tab-content">
     <Search />
     <FilterBar />
     {availableVariables.length > 0 ?
       <ScopeList { ...props } variables={ availableVariables } /> :
-      <EmptyState rawVariables={ rawVariables } />
+      <EmptyState rawVariables={ rawVariables } learnMoreUrl={ learnMoreUrl } />
     }
   </div>;
 }

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -7,19 +7,21 @@ import { ScopeExpandProvider } from './context/ScopeExpandContext';
  *
  * @param {Object} props
  * @param {*} props.injector
+ * @param {string} [props.learnMoreUrl]
  * @returns {import('react').ReactElement}
  */
 export default function VariableOutline(props) {
 
   const {
-    injector
+    injector,
+    learnMoreUrl
   } = props;
 
   return (
     <InjectorContext.Provider value={ injector }>
       <FilterProvider>
         <ScopeExpandProvider>
-          <TabContent />
+          <TabContent learnMoreUrl={ learnMoreUrl } />
         </ScopeExpandProvider>
       </FilterProvider>
     </InjectorContext.Provider>


### PR DESCRIPTION
Closes #56

### Proposed Changes

This pull request aims to sync empty state here with task-testing so that they look in harmony side-by-side.

**In the `main` branch**

<img width="2946" height="1944" alt="image" src="https://github.com/user-attachments/assets/f42e8fa2-cac7-4274-8f34-dcc1b6e2fd04" />

**Proposed iteration**

<img width="2946" height="1944" alt="image" src="https://github.com/user-attachments/assets/1de50e43-931d-4df8-8ed3-6a5f246755f7" />

<img width="2946" height="1944" alt="image" src="https://github.com/user-attachments/assets/3f6839b9-753b-45ba-a5b7-4f0dba935c16" />




### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
