### PR TITLE
chore(CollapseAllButton): remove custom styling

### DIFF
--- a/lib/components/FilterBar/CollapseAllButton.jsx
+++ b/lib/components/FilterBar/CollapseAllButton.jsx
@@ -12,7 +12,6 @@ export default function CollapseAllButton() {
 
   return (
     <IconButton
-      className="bio-vo-collapse-button"
       kind="ghost"
       size="sm"
       label={ label }

--- a/lib/components/FilterBar/FilterBar.scss
+++ b/lib/components/FilterBar/FilterBar.scss
@@ -21,30 +21,4 @@
     gap: 6px;
   }
 
-  .bio-vo-collapse-button {
-    border: 1px solid var(--cds-border-strong, #8d8d8d);
-    border-radius: 4px;
-    color: var(--cds-text-primary, #161616);
-
-    svg {
-      fill: var(--cds-icon-primary, #161616);
-    }
-
-    &:hover {
-      background-color: var(--cds-layer-hover, #e8e8e8);
-      color: var(--cds-text-primary, #161616);
-    }
-
-    &:focus,
-    &:focus-visible {
-      border-color: transparent;
-      outline: 2px solid var(--cds-focus, #0f62fe);
-      outline-offset: -2px;
-    }
-
-    &:active {
-      background-color: var(--cds-layer-active, #c6c6c6);
-    }
-  }
-
 }


### PR DESCRIPTION
Fixes #58

### Proposed Changes

This pull request aims to remove the custom styling from the collapse/expand all button so that the button is in sync/harmony with the other buttons in sibling panels.

**Before**

<img width="3274" height="1944" alt="image" src="https://github.com/user-attachments/assets/43f4b60d-fea1-4d39-bb2b-c7eb8e606da2" />

**After**

<img width="3186" height="1856" alt="image" src="https://github.com/user-attachments/assets/7b75ab80-8d43-468a-835d-db7fdcbf0a26" />



<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
