### PR TITLE
chore: align useService with injector strict semantics

### DIFF
--- a/lib/hooks/useService.js
+++ b/lib/hooks/useService.js
@@ -2,9 +2,9 @@ import { useContext } from 'react';
 import { InjectorContext } from '../context/InjectorContext';
 
 
-export default function useService(service, optional) {
+export default function useService(service, strict = true) {
 
   const injector = useContext(InjectorContext);
 
-  return injector.get(service, optional);
+  return injector.get(service, strict);
 }


### PR DESCRIPTION
Rename the `optional` parameter to `strict` with a default of `true`, matching the didi injector API convention. This removes the need for semantic inversion and makes references self-documenting.

### Proposed Changes

This pull request aims to correct the misconception of `strict`/`optional` in `useService` hook.

The existing callers of `useService` using the second argument (as `false` which should make the injected dependency "required") was [only in one place](https://github.com/bpmn-io/variable-outline/blob/main/lib/components/BpmnIcon/index.jsx#L65..L67) written as if it is optional. I'll leave the implementation details as-is, but improve the function signature only.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
