### PR TITLE
chore: add useTracking hook

### DIFF
--- a/lib/hooks/__test__/useTracking.spec.jsx
+++ b/lib/hooks/__test__/useTracking.spec.jsx
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import useTracking from '../useTracking';
+import { InjectorContext } from '../../context/InjectorContext';
+
+
+describe('#useTracking hook', () => {
+
+  it('should call bpmnJSTracking.track with namespaced name and data', () => {
+
+    // given
+    const mockService = {
+      track: vi.fn()
+    };
+
+    const mockInjector = {
+      get: (name) => name === 'bpmnJSTracking' ? mockService : null
+    };
+
+    const { result } = renderHook(
+      () => useTracking(),
+      { wrapper: createHookWrapper(mockInjector) }
+    );
+
+    // when
+    act(() => {
+      result.current('test-event', { foo: 'bar' });
+    });
+
+    // then
+    expect(mockService.track).toHaveBeenCalledWith({
+      name: 'variableOutline:test-event',
+      data: { foo: 'bar' }
+    });
+    expect(mockService.track).toHaveBeenCalledTimes(1);
+  });
+
+
+  it('should no-op when bpmnJSTracking service is absent', () => {
+
+    // given
+    const mockInjector = {
+      get: () => null
+    };
+
+    const { result } = renderHook(
+      () => useTracking(),
+      { wrapper: createHookWrapper(mockInjector) }
+    );
+
+    // when / then - should not throw
+    expect(() => {
+      act(() => {
+        result.current('test-event', { foo: 'bar' });
+      });
+    }).not.toThrow();
+  });
+
+
+  it('should always prepend variableOutline namespace', () => {
+
+    // given
+    const mockService = {
+      track: vi.fn()
+    };
+
+    const mockInjector = {
+      get: (name) => name === 'bpmnJSTracking' ? mockService : null
+    };
+
+    const { result } = renderHook(
+      () => useTracking(),
+      { wrapper: createHookWrapper(mockInjector) }
+    );
+
+    // when
+    act(() => {
+      result.current('searched', { cleared: false });
+      result.current('scopeToggled', { expanded: true });
+    });
+
+    // then
+    expect(mockService.track).toHaveBeenCalledTimes(2);
+    expect(mockService.track.mock.calls.every(
+      ([ { name } ]) => name.startsWith('variableOutline:')
+    )).toBe(true);
+  });
+
+});
+
+
+// helpers /////////////////////////
+
+function createHookWrapper(injector) {
+  return function HookWrapper({ children }) {
+    return (
+      <InjectorContext.Provider value={ injector }>
+        { children }
+      </InjectorContext.Provider>
+    );
+  };
+}

--- a/lib/hooks/useTracking.js
+++ b/lib/hooks/useTracking.js
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+import useService from './useService';
+
+const NAMESPACE = 'variableOutline';
+
+
+export default function useTracking() {
+  const bpmnJSTracking = useService('bpmnJSTracking', false);
+
+  return useCallback((name, data) => {
+    if (bpmnJSTracking) {
+      bpmnJSTracking.track({ name: `${NAMESPACE}:${name}`, data });
+    }
+  }, [ bpmnJSTracking ]);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,15 @@
         "vitest": "^4.0.18"
       },
       "peerDependencies": {
+        "bpmn-js-tracking": "*",
         "camunda-bpmn-js": "*",
         "react": "*",
         "react-dom": "*"
+      },
+      "peerDependenciesMeta": {
+        "bpmn-js-tracking": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,14 @@
     "vitest": "^4.0.18"
   },
   "peerDependencies": {
+    "bpmn-js-tracking": "*",
     "camunda-bpmn-js": "*",
     "react": "*",
     "react-dom": "*"
+  },
+  "peerDependenciesMeta": {
+    "bpmn-js-tracking": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
### Proposed Changes

This pull request aims to introduce a new React hook named `useTracking` that returns a function to fire tracking event. As the tracking is optional, the returned function may be no-op.

A short snippet of usage:
```js

function YetAnotherReactComponent() {
  const track = useTracking();

  React.useEffect(function viewEvent() {
    track('view');
  }, []);
}
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
