### PR TITLE
chore: track search usage

### DIFF
--- a/lib/components/Search/Search.jsx
+++ b/lib/components/Search/Search.jsx
@@ -1,16 +1,40 @@
+import { useEffect, useMemo } from 'react';
 import { Search as CarbonSearch, Tooltip } from '@carbon/react';
 import { Help } from '@carbon/icons-react';
+import { debounce } from 'min-dash';
 
 import useFilter from '../../hooks/useFilter';
+import useTracking from '../../hooks/useTracking';
 
 import './Search.scss';
+
+const SEARCH_DEBOUNCE_DELAY = 300;
 
 export default function Search() {
 
   const { search, setSearch } = useFilter();
+  const track = useTracking();
+
+  const trackSearch = useMemo(
+    () => debounce(() => {
+      track('searched');
+    }, SEARCH_DEBOUNCE_DELAY),
+    [ track ]
+  );
+
+  useEffect(() => {
+    return () => trackSearch.cancel();
+  }, [ trackSearch ]);
 
   const handleSearch = (event) => {
-    setSearch(event.target.value);
+    const value = event.target.value;
+    setSearch(value);
+
+    if (value.length > 0) {
+      trackSearch();
+    } else {
+      trackSearch.cancel();
+    }
   };
 
   return <div className="bio-vo-search-container">

--- a/lib/components/Search/__test__/Search.spec.jsx
+++ b/lib/components/Search/__test__/Search.spec.jsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import CamundaCloudModeler from 'camunda-bpmn-js/dist/camunda-cloud-modeler.development.js';
@@ -53,6 +53,142 @@ describe('lib/components/Search', function() {
 });
 
 
+describe('lib/components/Search - tracking', function() {
+
+  const mockTracking = { track: vi.fn() };
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    additionalModules: [ {
+      bpmnJSTracking: [ 'value', mockTracking ]
+    } ]
+  }));
+
+  beforeEach(() => vi.useFakeTimers());
+
+  afterEach(() => {
+    vi.useRealTimers();
+    mockTracking.track.mockClear();
+  });
+
+
+  it('should track search after debounce delay', inject(function(injector) {
+
+    // given
+    const { container } = render(<Search />, { wrapper: createWrapper(injector) });
+    const searchInput = container.querySelector('input');
+
+    // when
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: 'foo' } });
+    });
+
+    // then
+    expect(mockTracking.track).not.toHaveBeenCalled();
+
+    // when
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // then
+    expect(mockTracking.track).toHaveBeenCalledOnce();
+    expect(mockTracking.track).toHaveBeenCalledWith({
+      name: 'variableOutline:searched',
+      data: undefined
+    });
+  }));
+
+
+  it('should collapse rapid keystrokes into single event', inject(function(injector) {
+
+    // given
+    const { container } = render(<Search />, { wrapper: createWrapper(injector) });
+    const searchInput = container.querySelector('input');
+
+    // when
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: 'f' } });
+      fireEvent.change(searchInput, { target: { value: 'fo' } });
+      fireEvent.change(searchInput, { target: { value: 'foo' } });
+      vi.advanceTimersByTime(300);
+    });
+
+    // then
+    expect(mockTracking.track).toHaveBeenCalledOnce();
+    expect(mockTracking.track).toHaveBeenCalledWith({
+      name: 'variableOutline:searched',
+      data: undefined
+    });
+  }));
+
+
+  it('should NOT track when search is cleared', inject(function(injector) {
+
+    // given
+    const { container } = render(<Search />, { wrapper: createWrapper(injector) });
+    const searchInput = container.querySelector('input');
+
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: 'foo' } });
+      vi.advanceTimersByTime(300);
+    });
+
+    mockTracking.track.mockClear();
+
+    // when
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: '' } });
+      vi.advanceTimersByTime(300);
+    });
+
+    // then
+    expect(mockTracking.track).not.toHaveBeenCalled();
+  }));
+
+
+  it('should NOT include search term in tracking data', inject(function(injector) {
+
+    // given
+    const { container } = render(<Search />, { wrapper: createWrapper(injector) });
+    const searchInput = container.querySelector('input');
+
+    // when
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: 'sensitive-query' } });
+      vi.advanceTimersByTime(300);
+    });
+
+    // then
+    expect(mockTracking.track).toHaveBeenCalledWith({
+      name: 'variableOutline:searched',
+      data: undefined
+    });
+  }));
+
+
+  it('should not crash when tracking service is absent', function() {
+
+    // given
+    const injector = createMockInjector(null);
+
+    const { container } = render(<Search />, {
+      wrapper: createWrapper(injector)
+    });
+
+    const searchInput = container.querySelector('input');
+
+    // when / then
+    expect(() => {
+      act(() => {
+        fireEvent.change(searchInput, { target: { value: 'test' } });
+        vi.advanceTimersByTime(300);
+      });
+    }).not.toThrow();
+  });
+
+});
+
+
 // helpers /////////////////////////
 
 function SearchWithFilter({ filterRef }) {
@@ -64,6 +200,28 @@ function SearchWithFilter({ filterRef }) {
 
 function bootstrapModeler(diagram, options) {
   return bootstrapBpmnJS(CamundaCloudModeler, diagram, options);
+}
+
+function createMockInjector(trackingService) {
+  const mockEventBus = { on() {}, off() {} };
+
+  return {
+    get: (name, strict) => {
+      if (name === 'bpmnJSTracking') {
+        return trackingService;
+      }
+
+      if (name === 'eventBus') {
+        return mockEventBus;
+      }
+
+      if (strict !== false) {
+        throw new Error(`No provider for "${ name }"!`);
+      }
+
+      return null;
+    }
+  };
 }
 
 function createWrapper(injector) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@codemirror/language": "^6.12.2",
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.39.16",
-        "@lezer/highlight": "^1.2.3"
+        "@lezer/highlight": "^1.2.3",
+        "min-dash": "^5.0.0"
       },
       "devDependencies": {
         "@testing-library/react": "^16.0.0",
@@ -5724,7 +5725,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
       "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/min-dom": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@codemirror/language": "^6.12.2",
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.39.16",
-    "@lezer/highlight": "^1.2.3"
+    "@lezer/highlight": "^1.2.3",
+    "min-dash": "^5.0.0"
   },
   "devDependencies": {
     "@testing-library/react": "^16.0.0",


### PR DESCRIPTION
### Proposed Changes

This pull request aims to introduce a tracking event for the search action. We are currently not debouncing the search function, but debouncing the tracking function is something we should already have.

I plan to test some diagrams with 500-1000 variables in the list and search among them to see if it makes sense to also debounce the search function to smoothen the user-experience if needed.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
