### PR TITLE
chore: track copy action usage

### DIFF
--- a/lib/components/CopyButton.jsx
+++ b/lib/components/CopyButton.jsx
@@ -1,8 +1,15 @@
 import { Copy, Checkmark } from '@carbon/icons-react';
 import useClipboardCopy from '../hooks/useClipboardCopy';
+import useTracking from '../hooks/useTracking';
 
 export default function CopyButton({ text }) {
   const { copied, copy } = useClipboardCopy(text);
+  const track = useTracking();
+
+  const handleClick = (event) => {
+    copy(event);
+    track('variableNameCopy');
+  };
 
   return (
     <button
@@ -10,7 +17,7 @@ export default function CopyButton({ text }) {
       type="button"
       title="Copy variable name"
       aria-label="Copy variable name"
-      onClick={ copy }
+      onClick={ handleClick }
     >
       <span aria-live="polite" style={ { display: 'none' } }>
         { copied ? 'Copied to clipboard!' : '' }

--- a/lib/components/ScopeList/__test__/ScopeList.spec.jsx
+++ b/lib/components/ScopeList/__test__/ScopeList.spec.jsx
@@ -28,7 +28,7 @@ describe('lib/components/ScopeList', () => {
 
   describe('given no element is selected', () => {
 
-    it('renders all output variables in a single global scope group, sorted alphabetically', inject(async (variableResolver, selection, injector) => {
+    it('renders all output variables in a single global scope group, sorted alphabetically', inject(async (variableResolver, selection) => {
 
       // when
       const { availableVariables } = await getVariables({ variableResolver, selection, filter: defaultFilter });
@@ -203,7 +203,7 @@ describe('lib/components/ScopeList', () => {
 
   describe('variable row interaction', () => {
 
-    it('expands a row on click to reveal Written by details', inject(async (variableResolver, selection, injector) => {
+    it('expands a row on click to reveal Written by details', inject(async (variableResolver, selection) => {
 
       // given
       const { availableVariables } = await getVariables({ variableResolver, selection, filter: defaultFilter });
@@ -223,7 +223,7 @@ describe('lib/components/ScopeList', () => {
       expect(container.textContent).to.include('ProcessStartEvent');
     }));
 
-    it('copies variable name to clipboard and updates button state', inject(async (variableResolver, selection, injector) => {
+    it('copies variable name to clipboard and updates button state', inject(async (variableResolver, selection) => {
 
       // given
       const clipboardWrite = vi.fn(() => Promise.resolve());
@@ -260,8 +260,8 @@ describe('lib/components/ScopeList', () => {
 
 // helpers /////////////////////////
 
-function bootstrapModeler(diagram, options) {
-  return bootstrapBpmnJS(CamundaCloudModeler, diagram, options);
+function bootstrapModeler(diagram) {
+  return bootstrapBpmnJS(CamundaCloudModeler, diagram);
 }
 
 const getVariablesByScope = (container) => {

--- a/lib/components/VariableRow/__test__/ValueDisplay.spec.jsx
+++ b/lib/components/VariableRow/__test__/ValueDisplay.spec.jsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import ValueDisplay from '../ValueDisplay';
+import { InjectorContext } from '../../../context/InjectorContext';
 
 
 const NESTED_ENTRIES = [
@@ -167,16 +168,21 @@ async function unfoldEditor(editor) {
   });
 }
 
-function renderValueDisplay(overrides = {}) {
+function renderValueDisplay() {
+  const mockInjector = {
+    get: () => null
+  };
+
   return render(
-    <ValueDisplay
-      info={ null }
-      type={ null }
-      isList={ false }
-      variableName="testVar"
-      entries={ NESTED_ENTRIES }
-      { ...overrides }
-    />
+    <InjectorContext.Provider value={ mockInjector }>
+      <ValueDisplay
+        info={ null }
+        type={ null }
+        isList={ false }
+        variableName="testVar"
+        entries={ NESTED_ENTRIES }
+      />
+    </InjectorContext.Provider>
   );
 }
 

--- a/lib/components/__test__/CopyButton.spec.jsx
+++ b/lib/components/__test__/CopyButton.spec.jsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { act } from 'react';
+
+import CopyButton from '../CopyButton';
+import { InjectorContext } from '../../context/InjectorContext';
+
+
+describe('#CopyButton tracking', () => {
+
+  it('should track variableNameCopy when clicking copy button', async () => {
+
+    // given
+    const trackSpy = vi.fn();
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn(() => Promise.resolve()) },
+      configurable: true
+    });
+
+    const { container } = render(
+      <CopyButton text="myVariable" />,
+      { wrapper: createWrapper(trackSpy) }
+    );
+
+    // when
+    await act(async () => {
+      fireEvent.click(container.querySelector('.variable-copy-button'));
+    });
+
+    // then
+    expect(trackSpy).toHaveBeenCalledWith({
+      name: 'variableOutline:variableNameCopy',
+      data: undefined
+    });
+  });
+
+});
+
+
+// helpers /////////////////////////
+
+function createWrapper(trackSpy) {
+  const mockInjector = {
+    get: (name) => {
+      if (name === 'bpmnJSTracking') {
+        return { track: trackSpy };
+      }
+      return null;
+    }
+  };
+
+  return function TestWrapper({ children }) {
+    return (
+      <InjectorContext.Provider value={ mockInjector }>
+        { children }
+      </InjectorContext.Provider>
+    );
+  };
+}

--- a/lib/context/__test__/FilterContext.spec.jsx
+++ b/lib/context/__test__/FilterContext.spec.jsx
@@ -141,8 +141,8 @@ describe('lib/context/FilterContext', () => {
 });
 
 
-function bootstrapModeler(diagram, options) {
-  return bootstrapBpmnJS(CamundaCloudModeler, diagram, options);
+function bootstrapModeler(diagram) {
+  return bootstrapBpmnJS(CamundaCloudModeler, diagram);
 }
 
 function createHookWrapper(injector) {

--- a/lib/hooks/__test__/useContextMenuBehavior.spec.jsx
+++ b/lib/hooks/__test__/useContextMenuBehavior.spec.jsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import useContextMenuBehavior from '../useContextMenuBehavior';
+import { InjectorContext } from '../../context/InjectorContext';
+
+vi.mock('../../components/CodeMirrorEditor/jsonTreeUtils', () => ({
+  getLineContext: vi.fn(() => ({
+    propertyNode: {},
+    valueNode: {}
+  })),
+  buildPathFromSyntaxNode: vi.fn(() => '.foo'),
+  extractValue: vi.fn(() => '"bar"')
+}));
+
+
+describe('#useContextMenuBehavior tracking', () => {
+
+  it('should track variablePathCopy when copying path', () => {
+
+    // given
+    const trackSpy = vi.fn();
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn(() => Promise.resolve()) },
+      configurable: true
+    });
+
+    const menuState = { anchorPos: 0, rect: { bottom: 0, right: 0 } };
+    const view = createMockView();
+    const onClose = vi.fn();
+
+    const { result } = renderHook(
+      () => useContextMenuBehavior({ menuState, view, rootVariableName: 'myVar', onClose }),
+      { wrapper: createWrapper(trackSpy) }
+    );
+
+    // when
+    act(() => {
+      result.current.copyPath();
+    });
+
+    // then
+    expect(trackSpy).toHaveBeenCalledWith({
+      name: 'variableOutline:variablePathCopy',
+      data: undefined
+    });
+  });
+
+
+  it('should track variableValueCopy when copying value', () => {
+
+    // given
+    const trackSpy = vi.fn();
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn(() => Promise.resolve()) },
+      configurable: true
+    });
+
+    const menuState = { anchorPos: 0, rect: { bottom: 0, right: 0 } };
+    const view = createMockView();
+    const onClose = vi.fn();
+
+    const { result } = renderHook(
+      () => useContextMenuBehavior({ menuState, view, rootVariableName: 'myVar', onClose }),
+      { wrapper: createWrapper(trackSpy) }
+    );
+
+    // when
+    act(() => {
+      result.current.copyValue();
+    });
+
+    // then
+    expect(trackSpy).toHaveBeenCalledWith({
+      name: 'variableOutline:variableValueCopy',
+      data: undefined
+    });
+  });
+
+});
+
+
+// helpers /////////////////////////
+
+function createMockView() {
+  return { state: { doc: {} } };
+}
+
+function createWrapper(trackSpy) {
+  const mockInjector = {
+    get: (name) => {
+      if (name === 'bpmnJSTracking') {
+        return { track: trackSpy };
+      }
+      return null;
+    }
+  };
+
+  return function TestWrapper({ children }) {
+    return (
+      <InjectorContext.Provider value={ mockInjector }>
+        { children }
+      </InjectorContext.Provider>
+    );
+  };
+}

--- a/lib/hooks/__test__/useVariables.spec.jsx
+++ b/lib/hooks/__test__/useVariables.spec.jsx
@@ -245,8 +245,8 @@ describe('#useVariables hook sync behavior', () => {
 
 // helpers /////////////////////////
 
-function bootstrapModeler(diagram, options) {
-  return bootstrapBpmnJS(CamundaCloudModeler, diagram, options);
+function bootstrapModeler(diagram) {
+  return bootstrapBpmnJS(CamundaCloudModeler, diagram);
 }
 
 function createHookWrapper(injector) {

--- a/lib/hooks/useClipboardCopy.js
+++ b/lib/hooks/useClipboardCopy.js
@@ -19,7 +19,7 @@ export default function useClipboardCopy(text) {
         if (copyTimeout.current) clearTimeout(copyTimeout.current);
         copyTimeout.current = setTimeout(() => setCopied(false), 1500);
       })
-      .catch((error) => console.warning('[bpmn-io/variable-outline] Failed to copy to clipboard', error));
+      .catch((error) => console.warn('[bpmn-io/variable-outline] Failed to copy to clipboard', error));
   }, [ text ]);
 
   return { copied, copy };

--- a/lib/hooks/useContextMenuBehavior.js
+++ b/lib/hooks/useContextMenuBehavior.js
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { buildPathFromSyntaxNode, extractValue, getLineContext } from '../components/CodeMirrorEditor/jsonTreeUtils';
+import useTracking from './useTracking';
 
 export default function useContextMenuBehavior({ menuState, view, rootVariableName, onClose }) {
+  const track = useTracking();
   const menuRef = useRef(null);
   const firstItemRef = useRef(null);
 
@@ -58,13 +60,14 @@ export default function useContextMenuBehavior({ menuState, view, rootVariableNa
       if (path) {
         navigator.clipboard
           .writeText(path)
-          .catch((error) => console.warning('[bpmn-io/variable-outline] Failed to copy to clipboard', error));
+          .catch((error) => console.warn('[bpmn-io/variable-outline] Failed to copy to clipboard', error));
 
+        track('variablePathCopy');
       }
     }
 
     onClose();
-  }, [ menuState, view, rootVariableName, onClose ]);
+  }, [ menuState, view, rootVariableName, onClose, track ]);
 
   const copyValue = useCallback(() => {
     const { anchorPos } = menuState;
@@ -74,11 +77,13 @@ export default function useContextMenuBehavior({ menuState, view, rootVariableNa
     if (value !== undefined) {
       navigator.clipboard
         .writeText(value)
-        .catch((error) => console.warning('[bpmn-io/variable-outline] Failed to copy to clipboard', error));
+        .catch((error) => console.warn('[bpmn-io/variable-outline] Failed to copy to clipboard', error));
+
+      track('variableValueCopy');
     }
 
     onClose();
-  }, [ menuState, view, onClose ]);
+  }, [ menuState, view, onClose, track ]);
 
   const style = menuState ? {
     top: menuState.rect.bottom + 2,


### PR DESCRIPTION
### Proposed Changes

This pull request aims to introduce a tracking event for the copy action.

| Event Name        | Action                                          |
| ----------------- | ----------------------------------------------- |
| variableNameCopy  | User copies a variable name via the copy button |
| variablePathCopy  | User copies a variable path via context menu    |
| variableValueCopy | User copies a variable value via context menu   |



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
