### PR TITLE
chore: track expand/collapse scope/variable usage

### DIFF
--- a/lib/components/Scope/Scope.jsx
+++ b/lib/components/Scope/Scope.jsx
@@ -7,11 +7,13 @@ import useService from '../../hooks/useService';
 import useExpandable from '../../hooks/useExpandable';
 import useFilter from '../../hooks/useFilter';
 import useScopeExpand from '../../hooks/useScopeExpand';
+import useTracking from '../../hooks/useTracking';
 
 export default function Scope({ scopeName, scope, variables, defaultExpanded = true, isLocal = false, scopeType = 'parent' }) {
   const [ expandedIds, handleToggle ] = useExpandable();
   const [ expanded, toggleExpanded ] = useScopeExpand(scope.id, defaultExpanded);
   const { selectedElementIds } = useFilter();
+  const track = useTracking();
 
   const elementRegistry = useService('elementRegistry');
   const element = elementRegistry.get(scope.id);
@@ -27,7 +29,11 @@ export default function Scope({ scopeName, scope, variables, defaultExpanded = t
         variable={ variable }
         isSelectedOrigin={ isSelectedOrigin }
         expanded={ expandedIds.has(variable.id) }
-        onToggle={ () => handleToggle(variable.id) }
+        onToggle={ () => {
+          const willExpand = !expandedIds.has(variable.id);
+          handleToggle(variable.id);
+          track(willExpand ? 'expandVariable' : 'collapseVariable');
+        } }
       />
     );
   });

--- a/lib/components/Scope/__test__/Scope.spec.jsx
+++ b/lib/components/Scope/__test__/Scope.spec.jsx
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { act } from 'react';
+
+import CamundaCloudModeler from 'camunda-bpmn-js/dist/camunda-cloud-modeler.development.js';
+
+import { bootstrapBpmnJS, inject } from 'bpmn-js/test/helper';
+
+import diagramXML from '../../../hooks/__test__/diagram.xml?raw';
+import { getVariables } from '../../../hooks/useVariables';
+import Scope from '../Scope';
+import { InjectorContext } from '../../../context/InjectorContext';
+import { ScopeExpandProvider } from '../../../context/ScopeExpandContext';
+import { FilterContext } from '../../../context/FilterContext';
+
+const defaultFilter = {
+  search: '',
+  setSearch: () => {},
+  selectedElementIds: [],
+  writtenOnly: false,
+  toggleWrittenOnly: () => {}
+};
+
+
+describe('#Scope variable tracking', () => {
+
+  beforeEach(bootstrapModeler(diagramXML));
+
+  it('should track expandVariable when expanding a collapsed variable row', inject(async (injector, variableResolver, selection) => {
+
+    // given
+    const trackSpy = vi.fn();
+    const { availableVariables } = await getVariables({ variableResolver, selection, filter: defaultFilter });
+    const scope = availableVariables[0].scope;
+
+    const { container } = render(
+      <Scope
+        scopeName="TestScope"
+        scope={ scope }
+        variables={ availableVariables }
+        defaultExpanded={ true }
+      />,
+      { wrapper: createWrapper(injector, trackSpy) }
+    );
+
+    // when
+    await act(() => {
+      fireEvent.click(container.querySelector('.variable-row-toggle'));
+    });
+
+    // then
+    expect(trackSpy).toHaveBeenCalledWith({
+      name: 'variableOutline:expandVariable',
+      data: undefined
+    });
+  }));
+
+
+  it('should track collapseVariable when collapsing an expanded variable row', inject(async (injector, variableResolver, selection) => {
+
+    // given
+    const trackSpy = vi.fn();
+    const { availableVariables } = await getVariables({ variableResolver, selection, filter: defaultFilter });
+    const scope = availableVariables[0].scope;
+
+    const { container } = render(
+      <Scope
+        scopeName="TestScope"
+        scope={ scope }
+        variables={ availableVariables }
+        defaultExpanded={ true }
+      />,
+      { wrapper: createWrapper(injector, trackSpy) }
+    );
+
+    const toggle = container.querySelector('.variable-row-toggle');
+
+    // when - expand then collapse
+    await act(() => { fireEvent.click(toggle); });
+    await act(() => { fireEvent.click(toggle); });
+
+    // then
+    expect(trackSpy).toHaveBeenCalledTimes(2);
+    expect(trackSpy).toHaveBeenLastCalledWith({
+      name: 'variableOutline:collapseVariable',
+      data: undefined
+    });
+  }));
+
+});
+
+
+// helpers /////////////////////////
+
+function bootstrapModeler(diagram, options) {
+  return bootstrapBpmnJS(CamundaCloudModeler, diagram, options);
+}
+
+function createWrapper(injector, trackSpy) {
+  const trackingInjector = {
+    get: (name, strict) => {
+      if (name === 'bpmnJSTracking') {
+        return { track: trackSpy };
+      }
+      return injector.get(name, strict);
+    }
+  };
+
+  return function TestWrapper({ children }) {
+    return (
+      <InjectorContext.Provider value={ trackingInjector }>
+        <FilterContext.Provider value={ defaultFilter }>
+          <ScopeExpandProvider>
+            { children }
+          </ScopeExpandProvider>
+        </FilterContext.Provider>
+      </InjectorContext.Provider>
+    );
+  };
+}

--- a/lib/hooks/__test__/useScopeExpand.spec.jsx
+++ b/lib/hooks/__test__/useScopeExpand.spec.jsx
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import CamundaCloudModeler from 'camunda-bpmn-js/dist/camunda-cloud-modeler.development.js';
+
+import { bootstrapBpmnJS, inject } from 'bpmn-js/test/helper';
+
+import diagramXML from './diagram.xml?raw';
+import useScopeExpand from '../useScopeExpand';
+import { InjectorContext } from '../../context/InjectorContext';
+import { ScopeExpandProvider } from '../../context/ScopeExpandContext';
+
+
+describe('#useScopeExpand tracking', () => {
+
+  beforeEach(bootstrapModeler(diagramXML));
+
+  it('should track collapseScope when collapsing an expanded scope', inject((injector) => {
+
+    // given
+    const trackSpy = vi.fn();
+    const { result } = renderHook(
+      () => useScopeExpand('scope-1', true),
+      { wrapper: createWrapper(injector, trackSpy) }
+    );
+
+    // when
+    act(() => {
+      result.current[1]();
+    });
+
+    // then
+    expect(trackSpy).toHaveBeenCalledWith({
+      name: 'variableOutline:collapseScope',
+      data: undefined
+    });
+  }));
+
+
+  it('should track expandScope when expanding a collapsed scope', inject((injector) => {
+
+    // given
+    const trackSpy = vi.fn();
+    const { result } = renderHook(
+      () => useScopeExpand('scope-1', false),
+      { wrapper: createWrapper(injector, trackSpy) }
+    );
+
+    // when
+    act(() => {
+      result.current[1]();
+    });
+
+    // then
+    expect(trackSpy).toHaveBeenCalledWith({
+      name: 'variableOutline:expandScope',
+      data: undefined
+    });
+  }));
+
+});
+
+
+// helpers /////////////////////////
+
+function bootstrapModeler(diagram, options) {
+  return bootstrapBpmnJS(CamundaCloudModeler, diagram, options);
+}
+
+function createWrapper(injector, trackSpy) {
+  const trackingInjector = {
+    get: (name, strict) => {
+      if (name === 'bpmnJSTracking') {
+        return { track: trackSpy };
+      }
+      return injector.get(name, strict);
+    }
+  };
+
+  return function HookWrapper({ children }) {
+    return (
+      <InjectorContext.Provider value={ trackingInjector }>
+        <ScopeExpandProvider>
+          { children }
+        </ScopeExpandProvider>
+      </InjectorContext.Provider>
+    );
+  };
+}

--- a/lib/hooks/useScopeExpand.js
+++ b/lib/hooks/useScopeExpand.js
@@ -1,6 +1,7 @@
 import { useContext, useCallback, useEffect } from 'react';
 
 import { ScopeExpandContext } from '../context/ScopeExpandContext';
+import useTracking from './useTracking';
 
 export default function useScopeExpand(scopeId, defaultExpanded = true) {
   const {
@@ -9,6 +10,8 @@ export default function useScopeExpand(scopeId, defaultExpanded = true) {
     registerScope,
     unregisterScope
   } = useContext(ScopeExpandContext);
+
+  const track = useTracking();
 
   useEffect(() => {
     registerScope(scopeId, defaultExpanded);
@@ -21,8 +24,10 @@ export default function useScopeExpand(scopeId, defaultExpanded = true) {
     : defaultExpanded;
 
   const toggle = useCallback(() => {
-    setExpanded(scopeId, !expanded);
-  }, [ scopeId, expanded, setExpanded ]);
+    const willExpand = !expanded;
+    setExpanded(scopeId, willExpand);
+    track(willExpand ? 'expandScope' : 'collapseScope');
+  }, [ scopeId, expanded, setExpanded, track ]);
 
   return [ expanded, toggle ];
 }


### PR DESCRIPTION
### Proposed Changes

This pull request aims to introduce a tracking event for the collapse/expand scope/variable action.

| Event Name        | Action                                          |
| ----------------- | ----------------------------------------------- |
| collapseScope     | User collapses a scope section                  |
| expandScope       | User expands a scope section                    |
| collapseVariable  | User collapses a variable row                   |
| expandVariable    | User expands a variable row                     |

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
