### PR TITLE
feat: reword search copy to reflect filter behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: add collapse/expand scope groups functionality ([#22](https://github.com/bpmn-io/variable-outline/pull/22))
 * `FIX`: auto align tooltip not to overflow ([#49](https://github.com/bpmn-io/variable-outline/pull/49))
 * `FIX`: prevent double-encoding of string values ([#53](https://github.com/bpmn-io/variable-outline/pull/53))
+* `CHORE`: reword search bar copy to reflect filter semantics ([#65](https://github.com/bpmn-io/variable-outline/pull/65))
 
 ## 2.0.1
 

--- a/lib/components/Search/Search.jsx
+++ b/lib/components/Search/Search.jsx
@@ -17,8 +17,8 @@ export default function Search() {
     <CarbonSearch
       className="bio-vo-search"
       size="md"
-      placeholder="Search variables for name, scope, or origin"
-      labelText="Search"
+      placeholder="Filter by name, origin, or scope"
+      labelText="Filter variables"
       onChange={ handleSearch }
       value={ search }
       type="inline"
@@ -26,7 +26,7 @@ export default function Search() {
 
     <Tooltip
       className="bio-vo-help"
-      label="This panel shows the variables accessible to the selected element, grouped by scope. Expand a variable to see which elements write it and what value it holds. Use the search or filters to narrow down the list."
+      label="This panel shows the variables accessible to the selected element, grouped by scope. Expand a variable to see which elements write it and what value it holds. Type in the input to filter by name, origin, or scope."
       align="bottom-end"
       autoAlign
     >

--- a/lib/components/Search/__test__/Search.spec.jsx
+++ b/lib/components/Search/__test__/Search.spec.jsx
@@ -15,7 +15,7 @@ describe('lib/components/Search', function() {
 
   beforeEach(bootstrapModeler(diagramXML));
 
-  it('should render search input', inject(function(injector) {
+  it('should render filter input', inject(function(injector) {
 
     // given
     const { container } = render(<Search />, { wrapper: createWrapper(injector) });
@@ -27,7 +27,7 @@ describe('lib/components/Search', function() {
   }));
 
 
-  it('should set search term', inject(async (injector) => {
+  it('should set filter term', inject(async (injector) => {
 
     // given
     const filterRef = { current: null };


### PR DESCRIPTION
### Proposed Changes

This pull request aims to reflect on the current behavior of the search bar which filters the shown variables rather than performing a search across the open diagram.

Cf. [internal communication](https://camunda.slack.com/archives/GP70M0J6M/p1773911904547949)

**Before**

<img width="610" height="391" alt="image" src="https://github.com/user-attachments/assets/3fc7a3fa-7eaa-4e40-a410-4b26e906e606" />


**After**

<img width="610" height="391" alt="image" src="https://github.com/user-attachments/assets/51ba33d2-07a6-434c-80b1-7d7d4bd82b69" />



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
