### PR TITLE
fix: allow tabbing out of CodeMirror editors

### DIFF
--- a/lib/components/CodeMirrorEditor/jsonInteractiveControls.js
+++ b/lib/components/CodeMirrorEditor/jsonInteractiveControls.js
@@ -243,7 +243,11 @@ function moveFocus(view, direction) {
   if (index === -1) {
     nextIndex = direction > 0 ? 0 : tokens.length - 1;
   } else {
-    nextIndex = (index + direction + tokens.length) % tokens.length;
+    nextIndex = index + direction;
+    if (nextIndex < 0 || nextIndex >= tokens.length) {
+      view.dispatch({ effects: setActiveTokenEffect.of(null) });
+      return false;
+    }
   }
 
   view.dispatch({


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-hub/pull/21494#pullrequestreview-3966387333

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Allow tabbing out of CodeMirror editors in the variable value box.

In the screencasts I'm spamming TAB.

#### Before

![vo-before](https://github.com/user-attachments/assets/e4fec8f5-7f86-4494-b34b-cf1292dba5c3)

#### After

![vo-after](https://github.com/user-attachments/assets/eb649943-450b-4e80-b580-ff933fb5d2c5)

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
