### PR TITLE
fix: adjust variable name font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: align panel styling with properties panel ([#68](https://github.com/bpmn-io/variable-outline/pull/68))
 * `FIX`: auto align tooltip not to overflow ([#49](https://github.com/bpmn-io/variable-outline/pull/49))
 * `FIX`: prevent double-encoding of string values ([#53](https://github.com/bpmn-io/variable-outline/pull/53))
+* `FIX`: adjust variable name font size for improved visual balance ([#70](https://github.com/bpmn-io/variable-outline/pull/70))
 
 ## 2.0.1
 

--- a/lib/components/outline-variables.scss
+++ b/lib/components/outline-variables.scss
@@ -206,7 +206,7 @@
 .variable-name {
   display: block;
   font-family: var(--font-family-monospace);
-  font-size: var(--font-size-default, 14px);
+  font-size: 13px;
   line-height: 18px;
   font-weight: 400;
   white-space: nowrap;


### PR DESCRIPTION
Closes camunda/camunda-modeler#5797

### Proposed Changes

This pull request aims to bring visual clarity by iterating the variable name's font-size.

<img width="857" height="501" alt="image" src="https://github.com/user-attachments/assets/2260d91f-8930-48a3-baac-f7f3c2afe05a" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
