### PR TITLE
feat: add tooltip to written by selection toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: add collapse/expand scope groups functionality ([#22](https://github.com/bpmn-io/variable-outline/pull/22))
 * `FEAT`: reword search bar copy to reflect filter semantics ([#65](https://github.com/bpmn-io/variable-outline/pull/65))
 * `FEAT`: align panel styling with properties panel ([#68](https://github.com/bpmn-io/variable-outline/pull/68))
+* `FEAT`: add tooltip to written by selection toggle ([#72](https://github.com/bpmn-io/variable-outline/pull/72))
 * `FIX`: auto align tooltip not to overflow ([#49](https://github.com/bpmn-io/variable-outline/pull/49))
 * `FIX`: prevent double-encoding of string values ([#53](https://github.com/bpmn-io/variable-outline/pull/53))
 

--- a/lib/components/FilterBar/FilterBar.scss
+++ b/lib/components/FilterBar/FilterBar.scss
@@ -22,6 +22,12 @@
     display: flex;
     align-items: center;
     gap: 6px;
+
+    .cds--toggle__text {
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 2px;
+    }
   }
 
 }

--- a/lib/components/FilterBar/WrittenOnlyToggle.jsx
+++ b/lib/components/FilterBar/WrittenOnlyToggle.jsx
@@ -1,4 +1,4 @@
-import { Toggle } from '@carbon/react';
+import { Toggle, Tooltip } from '@carbon/react';
 import useFilter from '../../hooks/useFilter';
 
 export default function WrittenOnlyToggle() {
@@ -9,17 +9,23 @@ export default function WrittenOnlyToggle() {
   };
 
   return (
-    <div className="bio-vo-written-only-toggle">
-      <Toggle
-        id="written-only-toggle"
-        size="sm"
-        labelText="Written by selection"
-        hideLabel
-        toggled={ writtenOnly }
-        onToggle={ handleToggle }
-        aria-label="Written by current selection"
-      />
-    </div>
+    <Tooltip
+      label="Only show variables written by the currently selected element."
+      align="bottom"
+      autoAlign
+    >
+      <div className="bio-vo-written-only-toggle">
+        <Toggle
+          id="written-only-toggle"
+          size="sm"
+          labelText="Written by selection"
+          hideLabel
+          toggled={ writtenOnly }
+          onToggle={ handleToggle }
+          aria-label="Written by current selection"
+        />
+      </div>
+    </Tooltip>
   );
 
 }


### PR DESCRIPTION
Wraps the WrittenOnlyToggle in a Carbon Tooltip to explain what the toggle does when hovered.

Closes camunda/camunda-modeler#5785

<img width="964" height="482" alt="image" src="https://github.com/user-attachments/assets/740a5798-62bf-40dc-a541-ccf569541648" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
