### PR TITLE
fix: sync horizontal border colors with details panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [@bpmn-io/variable-outline](https://github.com/bpmn-i
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: sync horizontal border colors with details panel ([#80](https://github.com/bpmn-io/variable-outline/pull/80))
+
 ## 3.0.0
 
 * `FEAT`: make layout vertical for variables ([#16](https://github.com/bpmn-io/variable-outline/pull/16))

--- a/lib/components/FilterBar/FilterBar.scss
+++ b/lib/components/FilterBar/FilterBar.scss
@@ -6,7 +6,7 @@
   box-sizing: border-box;
   height: 32px;
   padding: 0 4px 0 12px;
-  border-bottom: 1px solid var(--cds-border-subtle, hsl(225, 10%, 75%));
+  border-bottom: 1px solid var(--bio-vo-border-color);
   background-color: var(--bio-vo-header-bg);
   flex-shrink: 0;
 

--- a/lib/components/Search/Search.scss
+++ b/lib/components/Search/Search.scss
@@ -7,7 +7,7 @@
   height: 64px;
   padding: 8px 12px;
   background-color: var(--bio-vo-header-bg);
-  border-bottom: 1px solid var(--cds-border-subtle, hsl(225, 10%, 75%));
+  border-bottom: 1px solid var(--bio-vo-border-color);
   top: 0;
 
   .bio-vo-search {

--- a/lib/style.scss
+++ b/lib/style.scss
@@ -9,6 +9,7 @@
   --bio-vo-text-primary: #22242A;
   --bio-vo-text-secondary: #525252;
   --bio-vo-text-muted: #606060;
+  --bio-vo-border-color: var(--color-grey-225-10-75, hsl(225, 10%, 75%));
 
   height: 100%;
   max-height: 100%;


### PR DESCRIPTION
Introduce `--bio-vo-border-color` CSS custom property set to `hsl(225, 10%, 75%)`, matching the properties-panel header border color. Use it for the search container and filter bar bottom borders instead of the CDS `--cds-border-subtle` token, which resolves to a different shade in themed environments.

Closes #79

### Proposed Changes

In this branch, the horizontal border colors should be streamlined compared to details panel.

<img width="911" height="154" alt="image" src="https://github.com/user-attachments/assets/569e3fd1-a437-48f3-b7dd-7a8b5ca2c632" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
