### PR TITLE
fix: handle origin-less variables in search filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the [@bpmn-io/variable-outline](https://github.com/bpmn-i
 ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: preserve value preview expand state when value changes ([#83](https://github.com/bpmn-io/variable-outline/pull/83))
+* `FIX`: handle origin-less variables in search filter ([#88](https://github.com/bpmn-io/variable-outline/pull/88))
 
 ## 3.0.2
 

--- a/lib/hooks/__test__/useVariables.spec.jsx
+++ b/lib/hooks/__test__/useVariables.spec.jsx
@@ -102,6 +102,42 @@ describe('#getVariables', () => {
   }));
 
 
+  it('should filter by origin with origin-less variables in list', async () => {
+
+    // given
+    const variableResolver = {
+      getVariables: async () => ({
+        'Process_1': [
+          {
+            name: 'withOrigin',
+            origin: [ { id: 'Task_1', name: 'Task 1' } ],
+            scope: { id: 'Process_1', name: 'My Process', $type: 'bpmn:Process' }
+          },
+          {
+            name: 'withoutOrigin',
+            scope: { id: 'Process_1', name: 'My Process', $type: 'bpmn:Process' }
+          }
+        ]
+      })
+    };
+
+    const selection = { get: () => [] };
+
+    const filter = {
+      search: 'Task 1',
+      selectedElementIds: [],
+      writtenOnly: false
+    };
+
+    // when
+    const { filteredVariables } = await getVariables({ variableResolver, selection, filter });
+
+    // then
+    expect(filteredVariables).to.have.length(1);
+    expect(filteredVariables[0].name).to.eql('withOrigin');
+  });
+
+
   it('should filter for multi-select', inject(async (elementRegistry, variableResolver, selection) => {
 
     // given

--- a/lib/hooks/useVariables.js
+++ b/lib/hooks/useVariables.js
@@ -101,7 +101,7 @@ const searchFilter = search => variable => {
 
   // Filter Origin
   if (
-    variable.origin.find(element => {
+    variable.origin?.find(element => {
       return element.name?.toLowerCase().includes(search) || element.id.toLowerCase().includes(search);
     })
   ) {


### PR DESCRIPTION
### Proposed Changes

This pull request aims to fix the filtering logic for variable lists incl. origin-less variables as they're introduced along with variable-resolver@3.

See [internal communication](https://camunda.slack.com/archives/GP70M0J6M/p1775647392400559).


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
