### PR TITLE
fix: filter for existing scope before search filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: preserve value preview expand state when value changes ([#83](https://github.com/bpmn-io/variable-outline/pull/83))
 * `FIX`: use Carbon IconButton to improve tooltip alignment ([#87](https://github.com/bpmn-io/variable-outline/pull/87))
+* `FIX`: exclude variables without scope before applying the search filter to preserve original behavior ([#89](https://github.com/bpmn-io/variable-outline/pull/89))
 
 ## 3.0.2
 

--- a/lib/hooks/__test__/useVariables.spec.jsx
+++ b/lib/hooks/__test__/useVariables.spec.jsx
@@ -127,6 +127,42 @@ describe('#getVariables', () => {
     expect(availableVariables.map(v => v.name)).to.include('Task2Variable');
   }));
 
+
+  it('should filter by origin with origin-less variables in list', async () => {
+
+    // given
+    const variableResolver = {
+      getVariables: async () => ({
+        'Process_1': [
+          {
+            name: 'withOrigin',
+            origin: [ { id: 'Task_1', name: 'Task 1' } ],
+            scope: { id: 'Process_1', name: 'My Process', $type: 'bpmn:Process' }
+          },
+          {
+            name: 'withoutOrigin',
+            scope: { id: 'Process_1', name: 'My Process', $type: 'bpmn:Process' }
+          }
+        ]
+      })
+    };
+
+    const selection = { get: () => [] };
+
+    const filter = {
+      search: 'Task 1',
+      selectedElementIds: [],
+      writtenOnly: false
+    };
+
+    // when
+    const { filteredVariables } = await getVariables({ variableResolver, selection, filter });
+
+    // then
+    expect(filteredVariables).to.have.length(1);
+    expect(filteredVariables[0].name).to.eql('withOrigin');
+  });
+
 });
 
 

--- a/lib/hooks/useVariables.js
+++ b/lib/hooks/useVariables.js
@@ -45,10 +45,11 @@ export const getVariables = async ({ variableResolver, selection, filter }) => {
   // Variable resolver already caches the result, we do not need to care about calls without changes here
   const rawVariables = Object.values(await variableResolver.getVariables()).flat();
 
-  const filteredVariables = rawVariables.filter(searchFilter(filter.search));
+  const filteredVariables = rawVariables
+    .filter(variable => variable.scope && variable.origin)
+    .filter(searchFilter(filter.search));
 
   const availableVariables = filteredVariables
-    .filter(variable => variable.scope)
     .filter(scopeFilter(canvasSelection))
     .filter(writtenOnlyFilter(filter.writtenOnly, filter.selectedElementIds));
 


### PR DESCRIPTION
### Proposed Changes

Alternative for https://github.com/bpmn-io/variable-outline/pull/88

filter for existing scope & origin (as defined originally to preserve legacy types) before search filter


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
