### PR TITLE
fix(FilterContext): seed selectedElementIds from current selection on mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FIX`: preserve value preview expand state when value changes ([#83](https://github.com/bpmn-io/variable-outline/pull/83))
 * `FIX`: use Carbon IconButton to improve tooltip alignment ([#87](https://github.com/bpmn-io/variable-outline/pull/87))
 * `FIX`: exclude variables without scope before applying the search filter to preserve original behavior ([#89](https://github.com/bpmn-io/variable-outline/pull/89))
+* `FIX`: seed selection state on mount to reflect pre-existing canvas selection ([#90](https://github.com/bpmn-io/variable-outline/pull/90))
 
 ## 3.0.2
 

--- a/lib/components/Search/__test__/Search.spec.jsx
+++ b/lib/components/Search/__test__/Search.spec.jsx
@@ -204,6 +204,7 @@ function bootstrapModeler(diagram, options) {
 
 function createMockInjector(trackingService) {
   const mockEventBus = { on() {}, off() {} };
+  const mockSelection = { get() { return []; } };
 
   return {
     get: (name, strict) => {
@@ -213,6 +214,10 @@ function createMockInjector(trackingService) {
 
       if (name === 'eventBus') {
         return mockEventBus;
+      }
+
+      if (name === 'selection') {
+        return mockSelection;
       }
 
       if (strict !== false) {

--- a/lib/context/FilterContext.jsx
+++ b/lib/context/FilterContext.jsx
@@ -12,6 +12,7 @@ export const FilterContext = createContext({
 
 export function FilterProvider({ children }) {
   const eventBus = useService('eventBus');
+  const selection = useService('selection');
 
   const [ filter, setFilter ] = useState({
     search: '',
@@ -19,23 +20,33 @@ export function FilterProvider({ children }) {
     writtenOnly: false
   });
 
-  const onSelectionChanged = useCallback((e) => {
-    const selected = e.newSelection || [];
-    const elementIds = selected.map(el => el.id);
-
-    setFilter(prev => ({
-      ...prev,
-      selectedElementIds: elementIds
-    }));
-  }, []);
-
   useEffect(() => {
+    function onSelectionChanged(e) {
+      const selected = e.newSelection || [];
+
+      setFilter(prev => ({
+        ...prev,
+        selectedElementIds: selected.map(el => el.id)
+      }));
+    }
+
     eventBus.on('selection.changed', onSelectionChanged);
 
     return () => {
       eventBus.off('selection.changed', onSelectionChanged);
     };
-  }, [ eventBus, onSelectionChanged ]);
+  }, [ eventBus ]);
+
+  useEffect(() => {
+    const currentSelection = selection.get();
+
+    if (currentSelection.length) {
+      setFilter(prev => ({
+        ...prev,
+        selectedElementIds: currentSelection.map(el => el.id)
+      }));
+    }
+  }, [ selection ]);
 
   const setSearch = useCallback((value) => {
     setFilter(prev => ({

--- a/lib/context/__test__/FilterContext.spec.jsx
+++ b/lib/context/__test__/FilterContext.spec.jsx
@@ -98,6 +98,20 @@ describe('lib/context/FilterContext', () => {
     });
   }));
 
+  it('should seed selectedElementIds from current selection on mount', inject(async (elementRegistry, selection, injector) => {
+
+    // given
+    selection.select(elementRegistry.get('Task_1'));
+
+    // when
+    const { result } = renderHook(() => useFilter(), { wrapper: createHookWrapper(injector) });
+
+    // then
+    await waitFor(() => {
+      expect(result.current.selectedElementIds).to.eql([ 'Task_1' ]);
+    });
+  }));
+
   it('should sync selectedElementIds on selection.changed', inject(async (elementRegistry, selection, injector) => {
 
     // given

--- a/lib/context/__test__/FilterContext.spec.jsx
+++ b/lib/context/__test__/FilterContext.spec.jsx
@@ -112,6 +112,59 @@ describe('lib/context/FilterContext', () => {
     });
   }));
 
+  it('should seed multiple selectedElementIds from current selection on mount', inject(async (elementRegistry, selection, injector) => {
+
+    // given
+    selection.select([
+      elementRegistry.get('Task_1'),
+      elementRegistry.get('Task_2')
+    ]);
+
+    // when
+    const { result } = renderHook(() => useFilter(), { wrapper: createHookWrapper(injector) });
+
+    // then
+    await waitFor(() => {
+      expect(result.current.selectedElementIds).to.eql([ 'Task_1', 'Task_2' ]);
+    });
+  }));
+
+  it('should replace initial selection with new selection', inject(async (elementRegistry, selection, injector) => {
+
+    // given
+    selection.select(elementRegistry.get('Task_1'));
+
+    const { result } = renderHook(() => useFilter(), { wrapper: createHookWrapper(injector) });
+
+    // when
+    await act(() => {
+      selection.select(elementRegistry.get('Task_2'));
+    });
+
+    // then
+    await waitFor(() => {
+      expect(result.current.selectedElementIds).to.eql([ 'Task_2' ]);
+    });
+  }));
+
+  it('should clear selectedElementIds when selection is cleared', inject(async (elementRegistry, selection, injector) => {
+
+    // given
+    selection.select(elementRegistry.get('Task_1'));
+
+    const { result } = renderHook(() => useFilter(), { wrapper: createHookWrapper(injector) });
+
+    // when
+    await act(() => {
+      selection.select([]);
+    });
+
+    // then
+    await waitFor(() => {
+      expect(result.current.selectedElementIds).to.eql([]);
+    });
+  }));
+
   it('should sync selectedElementIds on selection.changed', inject(async (elementRegistry, selection, injector) => {
 
     // given


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5846

### Proposed Changes

This pull request aims to initialize filter context with existing selection provided by the selection service. The behavior can be tested via web modeler as the URL persists the canvas selection with a query string like `selection=Activity_0kce977`, which the web modeler uses to restore the selection upon revisits.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
