### PR TITLE
feat: remove inner brackets from value preview fold placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [@bpmn-io/variable-outline](https://github.com/bpmn-i
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: remove inner brackets from value preview fold placeholder ([#92](https://github.com/bpmn-io/variable-outline/pull/92))
+
 ## 3.0.3
 
 * `FIX`: preserve value preview expand state when value changes ([#83](https://github.com/bpmn-io/variable-outline/pull/83))

--- a/lib/components/CodeMirrorEditor/foldPreview.js
+++ b/lib/components/CodeMirrorEditor/foldPreview.js
@@ -56,13 +56,13 @@ function buildPlaceholderDOM(view, onclick, prepared) {
   const { keys, total, open } = prepared;
 
   if (open === '[') {
-    span.textContent = `[ ${total} item${total === 1 ? '' : 's'} ]`;
+    span.textContent = ` ${total} item${total === 1 ? '' : 's'} `;
     return span;
   }
 
   const hasMore = total > PREVIEW_KEYS;
   const parts = hasMore ? [ ...keys, '…' ] : keys;
-  span.textContent = `{ ${parts.join(', ')} }`;
+  span.textContent = ` ${parts.join(', ')} `;
   return span;
 }
 

--- a/lib/components/VariableRow/__test__/ValueDisplay.spec.jsx
+++ b/lib/components/VariableRow/__test__/ValueDisplay.spec.jsx
@@ -141,6 +141,20 @@ describe('ValueDisplay', () => {
       });
     });
 
+    it('should not start or end fold placeholder with brackets', async () => {
+
+      // given
+      const { container } = renderValueDisplay();
+      const editor = await waitForEditor(container);
+
+      // when
+      const placeholder = editor.querySelector('.vd-fold-placeholder');
+
+      // then
+      expect(placeholder.textContent).not.to.match(/^[[{]/);
+      expect(placeholder.textContent).not.to.match(/[\]}]$/);
+    });
+
   });
 });
 


### PR DESCRIPTION
Related to camunda/camunda-modeler#5928

### Proposed Changes

This pull request aims to remove the repeated opening and closing brackets in the value previews for variables.

**Before**

<img width="395" alt="image" src="https://github.com/user-attachments/assets/46dbf184-ebcf-4a82-9960-8817214244fb" />

**After**

<img width="395" alt="image" src="https://github.com/user-attachments/assets/46bb19b8-ad6c-4e1b-9200-b5070992c34b" />



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
