### PR TITLE
feat: display "Used by" section in expanded variable row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: remove inner brackets from value preview fold placeholder ([#92](https://github.com/bpmn-io/variable-outline/pull/92))
 * `FEAT`: highlight root scope when nothing is selected in the canvas ([#91](https://github.com/bpmn-io/variable-outline/pull/91))
+* `FEAT`: display "Used by" section showing elements that read a variable ([#94](https://github.com/bpmn-io/variable-outline/pull/94))
 
 ## 3.0.3
 

--- a/lib/components/VariableRow/VariableRow.jsx
+++ b/lib/components/VariableRow/VariableRow.jsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Code, Edit } from '@carbon/icons-react';
+import { ChevronRight, Code, Edit, View } from '@carbon/icons-react';
 import { Tooltip } from '@carbon/react';
 
 import CopyButton from '../CopyButton';
@@ -11,6 +11,9 @@ import { getName } from '../../utils/elementUtil';
 export default function VariableRow({ variable, isSelectedOrigin, expanded, onToggle }) {
   const writers = variable.origin;
   const writeCount = writers.length;
+
+  const readers = (variable.usedBy || []).filter(el => el && el.id);
+  const readCount = readers.length;
 
   const singleWriterName = writeCount === 1
     ? getName(writers[0])
@@ -60,6 +63,19 @@ export default function VariableRow({ variable, isSelectedOrigin, expanded, onTo
               )) }
             </CollapsibleDetailSection>
           ) }
+          { readCount > 0 && (readCount === 1 ? (
+            <div className="variable-detail-section variable-detail-section--inline">
+              <View className="variable-detail-label-icon" />
+              <span className="variable-detail-label-text">Used by</span>
+              <ElementEntry element={ readers[0] } inline />
+            </div>
+          ) : (
+            <CollapsibleDetailSection label={ `Used by ${readCount} elements` }>
+              { readers.map(r => (
+                <ElementEntry key={ r.id } element={ r } />
+              )) }
+            </CollapsibleDetailSection>
+          )) }
           { (variable.type || variable.info || variable.entries?.length > 0) && (
             <div className="variable-detail-section">
               <div className="variable-detail-label">

--- a/lib/components/VariableRow/__test__/VariableRow.spec.jsx
+++ b/lib/components/VariableRow/__test__/VariableRow.spec.jsx
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import VariableRow from '../VariableRow';
+import { InjectorContext } from '../../../context/InjectorContext';
+
+
+describe('VariableRow', () => {
+
+  describe('Used by section', () => {
+
+    it('should not render "Used by" section when usedBy is undefined', () => {
+
+      // given
+      const variable = {
+        name: 'myVar',
+        origin: [
+          { id: 'Task_1', name: 'Writer Task', $type: 'bpmn:Task' }
+        ],
+        usedBy: undefined
+      };
+
+      // when
+      renderVariableRow(variable);
+
+      // then
+      expect(screen.queryByText('Used by')).not.to.exist;
+    });
+
+    it('should not render "Used by" section when usedBy contains only strings', () => {
+
+      // given
+      const variable = {
+        name: 'myVar',
+        origin: [
+          { id: 'Task_1', name: 'Writer Task', $type: 'bpmn:Task' }
+        ],
+        usedBy: [ 'targetVar', 'anotherVar' ]
+      };
+
+      // when
+      renderVariableRow(variable);
+
+      // then
+      expect(screen.queryByText('Used by')).not.to.exist;
+    });
+
+    it('should render "Used by" section with single reader element', () => {
+
+      // given
+      const variable = {
+        name: 'myVar',
+        origin: [
+          { id: 'Task_1', name: 'Writer Task', $type: 'bpmn:Task' }
+        ],
+        usedBy: [
+          { id: 'Task_2', name: 'Reader Task', $type: 'bpmn:Task' }
+        ]
+      };
+
+      // when
+      renderVariableRow(variable);
+
+      // then
+      expect(screen.getByText('Used by')).to.exist;
+    });
+
+    it('should render "Used by" section with multiple reader elements', () => {
+
+      // given
+      const variable = {
+        name: 'myVar',
+        origin: [
+          { id: 'Task_1', name: 'Writer Task', $type: 'bpmn:Task' }
+        ],
+        usedBy: [
+          { id: 'Task_2', name: 'Reader Task 1', $type: 'bpmn:Task' },
+          { id: 'Task_3', name: 'Reader Task 2', $type: 'bpmn:Task' }
+        ]
+      };
+
+      // when
+      renderVariableRow(variable);
+
+      // then
+      expect(screen.getByText('Used by 2 elements')).to.exist;
+    });
+
+    it('should filter out strings and render only element readers', () => {
+
+      // given
+      const variable = {
+        name: 'myVar',
+        origin: [
+          { id: 'Task_1', name: 'Writer Task', $type: 'bpmn:Task' }
+        ],
+        usedBy: [
+          'targetVar',
+          { id: 'Task_2', name: 'Reader Task', $type: 'bpmn:Task' },
+          'anotherVar'
+        ]
+      };
+
+      // when
+      renderVariableRow(variable);
+
+      // then
+      expect(screen.getByText('Used by')).to.exist;
+      expect(screen.getAllByRole('button', { name: /Reader Task/ })).to.have.lengthOf(1);
+    });
+
+  });
+
+});
+
+
+// helpers /////////////////////////
+
+function renderVariableRow(variable) {
+  const mockInjector = {
+    get: (service) => {
+      const services = {
+        selection: { get: () => [] },
+        canvas: { scrollToElement: () => {} },
+        elementRegistry: { get: () => null }
+      };
+      return services[service];
+    }
+  };
+
+  return render(
+    <InjectorContext.Provider value={ mockInjector }>
+      <VariableRow
+        variable={ variable }
+        isSelectedOrigin={ false }
+        expanded={ true }
+        onToggle={ () => {} }
+      />
+    </InjectorContext.Provider>
+  );
+}


### PR DESCRIPTION
Related to camunda/camunda-modeler#5937

### Proposed Changes

This pull request aims to display the list of elements using the variable in the expanded state of a variable row.

The way how we visualize the "Used by" elements follows the same pattern with "Written by" elements.

Multiple readers, expanded
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1bc967ab-8834-4a94-a16c-59ba8a732679" />

Multiple readers, collapsed
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ab4321eb-8fb0-4f68-a464-adb101280e6c" />

Single reader, inline
<img width="300" alt="image" src="https://github.com/user-attachments/assets/513c47d9-8e9a-434c-9126-f75afb960158" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
