### PR TITLE
feat: highlight diagram elements on hover in variables panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the [@bpmn-io/variable-outline](https://github.com/bpmn-i
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: enhance FEEL syntax highlighting ([#96](https://github.com/bpmn-io/variable-outline/pull/96))
+* `FEAT`: highlight diagram elements when hovering over element entries and multi-element section headers ([#98](https://github.com/bpmn-io/variable-outline/pull/98))
 * `DEPS`: bump `@bpmn-io/lang-feel` to v4 ([#96](https://github.com/bpmn-io/variable-outline/pull/96))
 
 ## 3.1.0

--- a/lib/components/VariableRow/CollapsibleDetailSection.jsx
+++ b/lib/components/VariableRow/CollapsibleDetailSection.jsx
@@ -4,6 +4,8 @@ import { ChevronRight } from '@carbon/icons-react';
 export default function CollapsibleDetailSection({
   label,
   defaultExpanded = false,
+  onMouseEnter,
+  onMouseLeave,
   children
 }) {
 
@@ -17,6 +19,8 @@ export default function CollapsibleDetailSection({
         type="button"
         className="variable-detail-label variable-detail-label--collapsible"
         onClick={ toggleExpanded }
+        onMouseEnter={ onMouseEnter }
+        onMouseLeave={ onMouseLeave }
       >
         <ChevronRight className={ `variable-detail-chevron${!expanded ? '' : ' variable-detail-chevron--expanded'}` } />
         { label }

--- a/lib/components/VariableRow/ElementEntry.jsx
+++ b/lib/components/VariableRow/ElementEntry.jsx
@@ -1,14 +1,24 @@
+import { useMemo } from 'react';
+
 import useElementNavigation from '../../hooks/useElementNavigation';
+import useElementHighlight from '../../hooks/useElementHighlight';
 import { getName } from '../../utils/elementUtil';
 
 export default function ElementEntry({ element: bo, inline = false }) {
   const { isSelected, navigate } = useElementNavigation(bo);
 
+  const elements = useMemo(() => [ bo ], [ bo ]);
+  const { highlight, clearHighlight } = useElementHighlight(elements);
+
   const className = `variable-element-entry${inline ? ' variable-element-entry--inline' : ''}${isSelected ? ' variable-element-entry--selected' : ''}`;
 
   if (isSelected) {
     return (
-      <span className={ className }>
+      <span
+        className={ className }
+        onMouseEnter={ highlight }
+        onMouseLeave={ clearHighlight }
+      >
         { getName(bo) }
       </span>
     );
@@ -18,6 +28,8 @@ export default function ElementEntry({ element: bo, inline = false }) {
     <button
       className={ className }
       onClick={ navigate }
+      onMouseEnter={ highlight }
+      onMouseLeave={ clearHighlight }
       type="button"
     >
       { getName(bo) }

--- a/lib/components/VariableRow/VariableRow.jsx
+++ b/lib/components/VariableRow/VariableRow.jsx
@@ -5,6 +5,7 @@ import CopyButton from '../CopyButton';
 import ValueDisplay from './ValueDisplay';
 import ElementEntry from './ElementEntry';
 import CollapsibleDetailSection from './CollapsibleDetailSection';
+import useElementHighlight from '../../hooks/useElementHighlight';
 import { getName } from '../../utils/elementUtil';
 
 
@@ -14,6 +15,9 @@ export default function VariableRow({ variable, isSelectedOrigin, expanded, onTo
 
   const readers = (variable.usedBy || []).filter(el => el && el.id);
   const readCount = readers.length;
+
+  const { highlight: highlightWriters, clearHighlight: clearWriters } = useElementHighlight(writers);
+  const { highlight: highlightReaders, clearHighlight: clearReaders } = useElementHighlight(readers);
 
   const singleWriterName = writeCount === 1
     ? getName(writers[0])
@@ -57,7 +61,11 @@ export default function VariableRow({ variable, isSelectedOrigin, expanded, onTo
               <ElementEntry element={ writers[0] } inline />
             </div>
           ) : (
-            <CollapsibleDetailSection label={ writtenByTitle }>
+            <CollapsibleDetailSection
+              label={ writtenByTitle }
+              onMouseEnter={ highlightWriters }
+              onMouseLeave={ clearWriters }
+            >
               { writers.map(o => (
                 <ElementEntry key={ o.id } element={ o } />
               )) }
@@ -70,7 +78,11 @@ export default function VariableRow({ variable, isSelectedOrigin, expanded, onTo
               <ElementEntry element={ readers[0] } inline />
             </div>
           ) : (
-            <CollapsibleDetailSection label={ `Used by ${readCount} elements` }>
+            <CollapsibleDetailSection
+              label={ `Used by ${readCount} elements` }
+              onMouseEnter={ highlightReaders }
+              onMouseLeave={ clearReaders }
+            >
               { readers.map(r => (
                 <ElementEntry key={ r.id } element={ r } />
               )) }

--- a/lib/components/VariableRow/__test__/ElementEntry.spec.jsx
+++ b/lib/components/VariableRow/__test__/ElementEntry.spec.jsx
@@ -54,6 +54,21 @@ describe('ElementEntry', () => {
       expect(addMarker).not.toHaveBeenCalled();
     });
 
+    it('should clear highlight on unmount while hovered', () => {
+
+      // given
+      const element = { id: 'Task_1' };
+      const removeMarker = vi.fn();
+      const { container, unmount } = renderElementEntry(element, { removeMarker });
+      fireEvent.mouseEnter(container.querySelector('button'));
+
+      // when
+      unmount();
+
+      // then
+      expect(removeMarker).toHaveBeenCalledWith(element, 'bio-vo-highlight');
+    });
+
     it('should highlight selected element on mouse enter', () => {
 
       // given

--- a/lib/components/VariableRow/__test__/ElementEntry.spec.jsx
+++ b/lib/components/VariableRow/__test__/ElementEntry.spec.jsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+
+import ElementEntry from '../ElementEntry';
+import { InjectorContext } from '../../../context/InjectorContext';
+
+
+describe('ElementEntry', () => {
+
+  describe('hover highlighting', () => {
+
+    it('should highlight element on mouse enter', () => {
+
+      // given
+      const element = { id: 'Task_1' };
+      const addMarker = vi.fn();
+      const { container } = renderElementEntry(element, { addMarker });
+
+      // when
+      fireEvent.mouseEnter(container.querySelector('button'));
+
+      // then
+      expect(addMarker).toHaveBeenCalledWith(element, 'bio-vo-highlight');
+    });
+
+    it('should clear highlight on mouse leave', () => {
+
+      // given
+      const element = { id: 'Task_1' };
+      const removeMarker = vi.fn();
+      const { container } = renderElementEntry(element, { removeMarker });
+
+      // when
+      fireEvent.mouseLeave(container.querySelector('button'));
+
+      // then
+      expect(removeMarker).toHaveBeenCalledWith(element, 'bio-vo-highlight');
+    });
+
+    it('should not highlight bpmn:Process element', () => {
+
+      // given
+      const bo = {
+        id: 'Process_1',
+        $instanceOf: (type) => type === 'bpmn:Process'
+      };
+      const addMarker = vi.fn();
+      const { container } = renderElementEntry(bo, { addMarker });
+
+      // when
+      fireEvent.mouseEnter(container.querySelector('button'));
+
+      // then
+      expect(addMarker).not.toHaveBeenCalled();
+    });
+
+    it('should highlight selected element on mouse enter', () => {
+
+      // given
+      const bo = { id: 'Task_1' };
+      const addMarker = vi.fn();
+      const { container } = renderElementEntry(bo, { addMarker, selectedIds: [ 'Task_1' ] });
+
+      // when
+      fireEvent.mouseEnter(container.querySelector('span.variable-element-entry'));
+
+      // then
+      expect(addMarker).toHaveBeenCalledWith({ id: 'Task_1' }, 'bio-vo-highlight');
+    });
+
+  });
+
+});
+
+
+// helpers /////////////////////////
+
+function renderElementEntry(bo, { addMarker = vi.fn(), removeMarker = vi.fn(), selectedIds = [] } = {}) {
+  const registryElement = { id: bo.id };
+
+  const mockInjector = {
+    get: (service) => {
+      const services = {
+        selection: { get: () => selectedIds.map(id => ({ id })) },
+        canvas: {
+          scrollToElement: () => {},
+          addMarker,
+          removeMarker
+        },
+        elementRegistry: { get: (id) => id === bo.id ? registryElement : null }
+      };
+      return services[service];
+    }
+  };
+
+  return render(
+    <InjectorContext.Provider value={ mockInjector }>
+      <ElementEntry element={ bo } />
+    </InjectorContext.Provider>
+  );
+}

--- a/lib/components/VariableRow/__test__/VariableRow.spec.jsx
+++ b/lib/components/VariableRow/__test__/VariableRow.spec.jsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import VariableRow from '../VariableRow';
 import { InjectorContext } from '../../../context/InjectorContext';
@@ -111,18 +111,91 @@ describe('VariableRow', () => {
 
   });
 
+  describe('hover highlighting', () => {
+
+    it('should highlight all writers when hovering "Written by N elements"', () => {
+
+      // given
+      const writers = [
+        { id: 'Task_1', name: 'Writer 1', $type: 'bpmn:Task' },
+        { id: 'Task_2', name: 'Writer 2', $type: 'bpmn:Task' }
+      ];
+      const variable = { name: 'myVar', origin: writers };
+      const addMarker = vi.fn();
+      renderVariableRow(variable, { addMarker });
+
+      // when
+      fireEvent.mouseEnter(screen.getByText('Written by 2 elements').closest('button'));
+
+      // then
+      const highlightedElements = addMarker.mock.calls.map(([ el ]) => el.id);
+      expect(highlightedElements).toEqual([ 'Task_1', 'Task_2' ]);
+    });
+
+    it('should clear highlights for all writers on mouse leave', () => {
+
+      // given
+      const writers = [
+        { id: 'Task_1', name: 'Writer 1', $type: 'bpmn:Task' },
+        { id: 'Task_2', name: 'Writer 2', $type: 'bpmn:Task' }
+      ];
+      const variable = { name: 'myVar', origin: writers };
+      const removeMarker = vi.fn();
+      renderVariableRow(variable, { removeMarker });
+
+      // when
+      fireEvent.mouseLeave(screen.getByText('Written by 2 elements').closest('button'));
+
+      // then
+      const unhighlightedElements = removeMarker.mock.calls.map(([ el ]) => el.id);
+      expect(unhighlightedElements).toEqual([ 'Task_1', 'Task_2' ]);
+    });
+
+    it('should highlight all readers when hovering "Used by N elements"', () => {
+
+      // given
+      const variable = {
+        name: 'myVar',
+        origin: [ { id: 'Task_1', name: 'Writer', $type: 'bpmn:Task' } ],
+        usedBy: [
+          { id: 'Task_2', name: 'Reader 1', $type: 'bpmn:Task' },
+          { id: 'Task_3', name: 'Reader 2', $type: 'bpmn:Task' }
+        ]
+      };
+      const addMarker = vi.fn();
+      renderVariableRow(variable, { addMarker });
+
+      // when
+      fireEvent.mouseEnter(screen.getByText('Used by 2 elements').closest('button'));
+
+      // then
+      const highlightedElements = addMarker.mock.calls.map(([ el ]) => el.id);
+      expect(highlightedElements).toEqual([ 'Task_2', 'Task_3' ]);
+    });
+
+  });
+
 });
 
 
 // helpers /////////////////////////
 
-function renderVariableRow(variable) {
+function renderVariableRow(variable, { addMarker = vi.fn(), removeMarker = vi.fn() } = {}) {
+  const knownIds = [
+    ...variable.origin,
+    ...(variable.usedBy || []).filter(el => el && el.id)
+  ].map(el => el.id);
+
   const mockInjector = {
     get: (service) => {
       const services = {
         selection: { get: () => [] },
-        canvas: { scrollToElement: () => {} },
-        elementRegistry: { get: () => null }
+        canvas: {
+          scrollToElement: () => {},
+          addMarker,
+          removeMarker
+        },
+        elementRegistry: { get: (id) => knownIds.includes(id) ? { id } : null }
       };
       return services[service];
     }

--- a/lib/hooks/useElementHighlight.js
+++ b/lib/hooks/useElementHighlight.js
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import useService from './useService';
@@ -36,6 +36,10 @@ export default function useElementHighlight(businessObjects) {
       }
     }
   }, [ businessObjects, canvas, elementRegistry ]);
+
+  useEffect(() => {
+    return () => clearHighlight();
+  }, [ clearHighlight ]);
 
   return { highlight, clearHighlight };
 }

--- a/lib/hooks/useElementHighlight.js
+++ b/lib/hooks/useElementHighlight.js
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import useService from './useService';
+
+const HIGHLIGHT_MARKER = 'bio-vo-highlight';
+
+export default function useElementHighlight(businessObjects) {
+  const canvas = useService('canvas');
+  const elementRegistry = useService('elementRegistry');
+
+  const highlight = useCallback(() => {
+    for (const bo of businessObjects) {
+      if (is(bo, 'bpmn:Process')) {
+        continue;
+      }
+
+      const element = elementRegistry.get(bo.id);
+
+      if (element) {
+        canvas.addMarker(element, HIGHLIGHT_MARKER);
+      }
+    }
+  }, [ businessObjects, canvas, elementRegistry ]);
+
+  const clearHighlight = useCallback(() => {
+    for (const bo of businessObjects) {
+      if (is(bo, 'bpmn:Process')) {
+        continue;
+      }
+
+      const element = elementRegistry.get(bo.id);
+
+      if (element) {
+        canvas.removeMarker(element, HIGHLIGHT_MARKER);
+      }
+    }
+  }, [ businessObjects, canvas, elementRegistry ]);
+
+  return { highlight, clearHighlight };
+}

--- a/lib/style.scss
+++ b/lib/style.scss
@@ -44,6 +44,6 @@
 
 .djs-element.bio-vo-highlight .djs-outline {
   visibility: visible;
-  stroke: var(--element-selected-outline-stroke-color);
-  fill: var(--search-preselected-background-color) !important;
+  stroke: var(--element-selected-outline-stroke-color, hsl(205, 100%, 50%));
+  fill: var(--search-preselected-background-color, hsla(205, 100%, 50%, 15%)) !important;
 }

--- a/lib/style.scss
+++ b/lib/style.scss
@@ -41,3 +41,9 @@
   justify-content: center;
   width: fit-content;
 }
+
+.djs-element.bio-vo-highlight .djs-outline {
+  visibility: visible;
+  stroke: var(--element-selected-outline-stroke-color);
+  fill: var(--search-preselected-background-color) !important;
+}


### PR DESCRIPTION
### Proposed Changes

Add hover-based element highlighting to the variables panel: hovering over an element entry highlights that element on the canvas, and hovering over a "Written by N elements" or "Used by N elements" header highlights all corresponding elements simultaneously.

Related to camunda/camunda-modeler#5934

**Hover single element**

<img width="1400" height="750" alt="01-hover-single-element" src="https://github.com/user-attachments/assets/3bec8e6d-b9c7-44e0-ac7d-fe5280398e8c" />

**Hover multi-writers**
<img width="1400" height="750" alt="02-hover-multi-writers" src="https://github.com/user-attachments/assets/986b1459-62e3-446d-bf93-a9a1787bdc95" />

**Hover selected element**
<img width="1400" height="750" alt="03-hover-selected-element" src="https://github.com/user-attachments/assets/7314cb1c-9fc2-47c5-8978-595efb271e1b" />

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
