### PR TITLE
feat: reveal defining mapping entry when navigating to variable writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [@bpmn-io/variable-outline](https://github.com/bpmn-i
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: reveal the field defining a variable when navigating to its writer ([#100](https://github.com/bpmn-io/variable-outline/pull/100))
+
 ## 3.2.1
 
 * `FIX`: externalize the React JSX runtime to allow using with React 19 ([#103](https://github.com/bpmn-io/variable-outline/pull/103))

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ export function MyComponent(props) {
 }
 ```
 
+### Revealing the Defining Field
+> [!NOTE]
+> Clicking the element that writes a variable also reveals the properties panel field that
+> defines it. The field is resolved through `propertiesPanel#getEntryId(element, path)`, so
+> this requires `bpmn-js-properties-panel@>=5.63.0`; with an older panel the click only
+> selects the element. Fields contributed by element templates additionally need
+> `bpmn-js-element-templates@>=2.29.0`.
+
 ### Using Carbon Styles
 > [!NOTE]
 > This library does not include `@carbon` styles. If you need them, you must import them into your existing SCSS file:

--- a/example/Modeler/diagram.xml
+++ b/example/Modeler/diagram.xml
@@ -37,18 +37,21 @@
       <bpmn:outgoing>Flow_1lsaytj</bpmn:outgoing>
       <bpmn:outgoing>Flow_0zibli6</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:task id="Activity_ReimburseExpenses" name="Reimburse expenses">
-      <bpmn:incoming>Flow_0j33fwr</bpmn:incoming>
-      <bpmn:outgoing>Flow_07w4wvi</bpmn:outgoing>
-    </bpmn:task>
+    <bpmn:scriptTask id="Activity_ReimburseExpenses" name="Reimburse expenses">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=expenseAmount" resultVariable="reimbursementAmount" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1lsaytj</bpmn:incoming>
+      <bpmn:outgoing>Flow_0j33fwr</bpmn:outgoing>
+    </bpmn:scriptTask>
     <bpmn:exclusiveGateway id="Gateway_0v75kn8">
       <bpmn:incoming>Flow_07hh01v</bpmn:incoming>
       <bpmn:incoming>Flow_0zibli6</bpmn:incoming>
       <bpmn:outgoing>Flow_185jnzm</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:task id="Activity_1l5wj0t" name="Notify about approval">
-      <bpmn:incoming>Flow_1lsaytj</bpmn:incoming>
-      <bpmn:outgoing>Flow_0j33fwr</bpmn:outgoing>
+      <bpmn:incoming>Flow_0j33fwr</bpmn:incoming>
+      <bpmn:outgoing>Flow_07w4wvi</bpmn:outgoing>
     </bpmn:task>
     <bpmn:userTask id="Activity_ReviewExpenseReport_Manager" name="Review report - manager">
       <bpmn:extensionElements>
@@ -86,13 +89,13 @@
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_07hh01v" name="Rejected" sourceRef="Gateway_1wrjn3x" targetRef="Gateway_0v75kn8" />
     <bpmn:sequenceFlow id="Flow_02funv0" sourceRef="Activity_NotifyRejection" targetRef="Event_12u444u" />
-    <bpmn:sequenceFlow id="Flow_07w4wvi" sourceRef="Activity_ReimburseExpenses" targetRef="Event_0hfb7dz" />
+    <bpmn:sequenceFlow id="Flow_07w4wvi" sourceRef="Activity_1l5wj0t" targetRef="Event_0hfb7dz" />
     <bpmn:sequenceFlow id="Flow_0tqbv24" sourceRef="Activity_ReviewExpenseReport_Finance" targetRef="Gateway_18ir29z" />
-    <bpmn:sequenceFlow id="Flow_1lsaytj" name="Approved" sourceRef="Gateway_18ir29z" targetRef="Activity_1l5wj0t">
+    <bpmn:sequenceFlow id="Flow_1lsaytj" name="Approved" sourceRef="Gateway_18ir29z" targetRef="Activity_ReimburseExpenses">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=financeReviewOutcome = "approved"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0zibli6" name="Rejected" sourceRef="Gateway_18ir29z" targetRef="Gateway_0v75kn8" />
-    <bpmn:sequenceFlow id="Flow_0j33fwr" sourceRef="Activity_1l5wj0t" targetRef="Activity_ReimburseExpenses" />
+    <bpmn:sequenceFlow id="Flow_0j33fwr" sourceRef="Activity_ReimburseExpenses" targetRef="Activity_1l5wj0t" />
     <bpmn:sequenceFlow id="Flow_185jnzm" sourceRef="Gateway_0v75kn8" targetRef="Activity_NotifyRejection" />
     <bpmn:sequenceFlow id="Flow_0od82be" sourceRef="Activity_CreateExpenseReport" targetRef="Activity_ReviewExpenseReport_Manager" />
   </bpmn:process>
@@ -135,14 +138,14 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0pm9gw6" bpmnElement="Activity_ReimburseExpenses">
-        <dc:Bounds x="1230" y="200" width="100" height="80" />
+        <dc:Bounds x="1080" y="200" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_09jydn6" bpmnElement="Gateway_0v75kn8" isMarkerVisible="true">
         <dc:Bounds x="935" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1t06c0s" bpmnElement="Activity_1l5wj0t">
-        <dc:Bounds x="1080" y="200" width="100" height="80" />
+        <dc:Bounds x="1230" y="200" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0tgdcex" bpmnElement="Activity_NotifyRejection">

--- a/lib/components/Scope/Scope.jsx
+++ b/lib/components/Scope/Scope.jsx
@@ -19,19 +19,23 @@ export default function Scope({ scopeName, scope, variables, defaultExpanded = t
   const element = elementRegistry.get(scope.id);
   const ScopeIcon = element ? getSVGComponent(element) : null;
 
+  // a variable carries no id; within a scope its name identifies it, as the
+  // resolver keeps one record per name and scope
   const rows = variables.map(variable => {
+    const { name } = variable;
+
     const isSelectedOrigin = selectedElementIds.some(id =>
       variable.origin?.some(o => o.id === id)
     );
     return (
       <VariableRow
-        key={ variable.id }
+        key={ name }
         variable={ variable }
         isSelectedOrigin={ isSelectedOrigin }
-        expanded={ expandedIds.has(variable.id) }
+        expanded={ expandedIds.has(name) }
         onToggle={ () => {
-          const willExpand = !expandedIds.has(variable.id);
-          handleToggle(variable.id);
+          const willExpand = !expandedIds.has(name);
+          handleToggle(name);
           track(willExpand ? 'expandVariable' : 'collapseVariable');
         } }
       />

--- a/lib/components/Scope/__test__/Scope.spec.jsx
+++ b/lib/components/Scope/__test__/Scope.spec.jsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { act } from 'react';
 
 import CamundaCloudModeler from 'camunda-bpmn-js/dist/camunda-cloud-modeler.development.js';
@@ -85,6 +85,39 @@ describe('#Scope variable tracking', () => {
       name: 'variableOutline:collapseVariable',
       data: undefined
     });
+  }));
+
+});
+
+
+describe('#Scope variable expansion', () => {
+
+  beforeEach(bootstrapModeler(diagramXML));
+
+  it('should expand only the toggled variable row', inject(async (injector, variableResolver, selection) => {
+
+    // given
+    const { availableVariables } = await getVariables({ variableResolver, selection, filter: defaultFilter });
+    const [ first, second ] = availableVariables;
+
+    render(
+      <Scope
+        scopeName="TestScope"
+        scope={ first.scope }
+        variables={ availableVariables }
+        defaultExpanded={ true }
+      />,
+      { wrapper: createWrapper(injector, vi.fn()) }
+    );
+
+    // when
+    await act(() => {
+      fireEvent.click(screen.getByRole('button', { name: first.name }));
+    });
+
+    // then
+    expect(screen.getByRole('button', { name: first.name }).getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('button', { name: second.name }).getAttribute('aria-expanded')).toBe('false');
   }));
 
 });

--- a/lib/components/VariableRow/ElementEntry.jsx
+++ b/lib/components/VariableRow/ElementEntry.jsx
@@ -4,8 +4,8 @@ import useElementNavigation from '../../hooks/useElementNavigation';
 import useElementHighlight from '../../hooks/useElementHighlight';
 import { getName } from '../../utils/elementUtil';
 
-export default function ElementEntry({ element: bo, inline = false }) {
-  const { isSelected, navigate } = useElementNavigation(bo);
+export default function ElementEntry({ element: bo, variableName, inline = false }) {
+  const { isSelected, navigate } = useElementNavigation(bo, { variableName });
 
   const elements = useMemo(() => [ bo ], [ bo ]);
   const { highlight, clearHighlight } = useElementHighlight(elements);

--- a/lib/components/VariableRow/VariableRow.jsx
+++ b/lib/components/VariableRow/VariableRow.jsx
@@ -58,7 +58,7 @@ export default function VariableRow({ variable, isSelectedOrigin, expanded, onTo
             <div className="variable-detail-section variable-detail-section--inline">
               <Edit className="variable-detail-label-icon" />
               <span className="variable-detail-label-text">Written by</span>
-              <ElementEntry element={ writers[0] } inline />
+              <ElementEntry element={ writers[0] } variableName={ variable.name } inline />
             </div>
           ) : (
             <CollapsibleDetailSection
@@ -67,7 +67,7 @@ export default function VariableRow({ variable, isSelectedOrigin, expanded, onTo
               onMouseLeave={ clearWriters }
             >
               { writers.map(o => (
-                <ElementEntry key={ o.id } element={ o } />
+                <ElementEntry key={ o.id } element={ o } variableName={ variable.name } />
               )) }
             </CollapsibleDetailSection>
           ) }

--- a/lib/components/VariableRow/__test__/ElementEntry.spec.jsx
+++ b/lib/components/VariableRow/__test__/ElementEntry.spec.jsx
@@ -14,13 +14,13 @@ describe('ElementEntry', () => {
       // given
       const element = { id: 'Task_1' };
       const addMarker = vi.fn();
-      const { container } = renderElementEntry(element, { addMarker });
+      const { container, registryElement } = renderElementEntry(element, { addMarker });
 
       // when
       fireEvent.mouseEnter(container.querySelector('button'));
 
       // then
-      expect(addMarker).toHaveBeenCalledWith(element, 'bio-vo-highlight');
+      expect(addMarker).toHaveBeenCalledWith(registryElement, 'bio-vo-highlight');
     });
 
     it('should clear highlight on mouse leave', () => {
@@ -28,13 +28,13 @@ describe('ElementEntry', () => {
       // given
       const element = { id: 'Task_1' };
       const removeMarker = vi.fn();
-      const { container } = renderElementEntry(element, { removeMarker });
+      const { container, registryElement } = renderElementEntry(element, { removeMarker });
 
       // when
       fireEvent.mouseLeave(container.querySelector('button'));
 
       // then
-      expect(removeMarker).toHaveBeenCalledWith(element, 'bio-vo-highlight');
+      expect(removeMarker).toHaveBeenCalledWith(registryElement, 'bio-vo-highlight');
     });
 
     it('should not highlight bpmn:Process element', () => {
@@ -59,14 +59,14 @@ describe('ElementEntry', () => {
       // given
       const element = { id: 'Task_1' };
       const removeMarker = vi.fn();
-      const { container, unmount } = renderElementEntry(element, { removeMarker });
+      const { container, registryElement, unmount } = renderElementEntry(element, { removeMarker });
       fireEvent.mouseEnter(container.querySelector('button'));
 
       // when
       unmount();
 
       // then
-      expect(removeMarker).toHaveBeenCalledWith(element, 'bio-vo-highlight');
+      expect(removeMarker).toHaveBeenCalledWith(registryElement, 'bio-vo-highlight');
     });
 
     it('should highlight selected element on mouse enter', () => {
@@ -74,13 +74,92 @@ describe('ElementEntry', () => {
       // given
       const bo = { id: 'Task_1' };
       const addMarker = vi.fn();
-      const { container } = renderElementEntry(bo, { addMarker, selectedIds: [ 'Task_1' ] });
+      const { container, registryElement } = renderElementEntry(bo, { addMarker, selectedIds: [ 'Task_1' ] });
 
       // when
       fireEvent.mouseEnter(container.querySelector('span.variable-element-entry'));
 
       // then
-      expect(addMarker).toHaveBeenCalledWith({ id: 'Task_1' }, 'bio-vo-highlight');
+      expect(addMarker).toHaveBeenCalledWith(registryElement, 'bio-vo-highlight');
+    });
+
+  });
+
+
+  describe('revealing the defining field', () => {
+
+    it('should reveal the entry the panel resolves for the definition', async () => {
+
+      // given
+      const bo = writerBusinessObject('Task_1', 'foo');
+      const getEntryId = vi.fn(() => 'custom-entry-123');
+      const fire = vi.fn();
+      const { container } = renderElementEntry(bo, { variableName: 'foo', getEntryId, fire });
+
+      // when
+      fireEvent.click(container.querySelector('button'));
+      await flushDeferred();
+
+      // then
+      expect(getEntryId).toHaveBeenCalledWith(
+        { id: 'Task_1', businessObject: bo },
+        [ 'extensionElements', 'values', 0, 'outputParameters', 0, 'target' ]
+      );
+      expect(fire).toHaveBeenCalledWith('propertiesPanel.showEntry', { id: 'custom-entry-123' });
+    });
+
+
+    it('should not reveal when the panel resolves nothing', async () => {
+
+      // given
+      const bo = writerBusinessObject('Task_1', 'foo');
+      const fire = vi.fn();
+      const { container } = renderElementEntry(bo, {
+        variableName: 'foo',
+        getEntryId: () => null,
+        fire
+      });
+
+      // when
+      fireEvent.click(container.querySelector('button'));
+      await flushDeferred();
+
+      // then
+      expect(fire).not.toHaveBeenCalled();
+    });
+
+
+    it('should not reveal without a properties panel', async () => {
+
+      // given
+      const bo = writerBusinessObject('Task_1', 'foo');
+      const fire = vi.fn();
+      const { container } = renderElementEntry(bo, { variableName: 'foo', fire });
+
+      // when
+      fireEvent.click(container.querySelector('button'));
+      await flushDeferred();
+
+      // then
+      expect(fire).not.toHaveBeenCalled();
+    });
+
+
+    it('should not reveal without a variable name', async () => {
+
+      // given
+      const bo = writerBusinessObject('Task_1', 'foo');
+      const getEntryId = vi.fn(() => 'custom-entry-123');
+      const fire = vi.fn();
+      const { container } = renderElementEntry(bo, { getEntryId, fire });
+
+      // when
+      fireEvent.click(container.querySelector('button'));
+      await flushDeferred();
+
+      // then
+      expect(getEntryId).not.toHaveBeenCalled();
+      expect(fire).not.toHaveBeenCalled();
     });
 
   });
@@ -90,27 +169,62 @@ describe('ElementEntry', () => {
 
 // helpers /////////////////////////
 
-function renderElementEntry(bo, { addMarker = vi.fn(), removeMarker = vi.fn(), selectedIds = [] } = {}) {
-  const registryElement = { id: bo.id };
+function renderElementEntry(bo, {
+  addMarker = vi.fn(),
+  removeMarker = vi.fn(),
+  selectedIds = [],
+  variableName,
+  getEntryId,
+  fire = vi.fn()
+} = {}) {
+  const registryElement = { id: bo.id, businessObject: bo };
 
   const mockInjector = {
     get: (service) => {
       const services = {
-        selection: { get: () => selectedIds.map(id => ({ id })) },
+        selection: {
+          get: () => selectedIds.map(id => ({ id })),
+          select: () => {}
+        },
         canvas: {
           scrollToElement: () => {},
           addMarker,
           removeMarker
         },
-        elementRegistry: { get: (id) => id === bo.id ? registryElement : null }
+        elementRegistry: { get: (id) => id === bo.id ? registryElement : null },
+        eventBus: { fire },
+        propertiesPanel: getEntryId ? { getEntryId } : undefined
       };
       return services[service];
     }
   };
 
-  return render(
-    <InjectorContext.Provider value={ mockInjector }>
-      <ElementEntry element={ bo } />
-    </InjectorContext.Provider>
-  );
+  return {
+    ...render(
+      <InjectorContext.Provider value={ mockInjector }>
+        <ElementEntry element={ bo } variableName={ variableName } />
+      </InjectorContext.Provider>
+    ),
+    registryElement
+  };
+}
+
+function writerBusinessObject(id, target) {
+  const outputParameter = { get: key => key === 'target' ? target : undefined };
+
+  const ioMapping = {
+    $type: 'zeebe:IoMapping',
+    get: key => key === 'outputParameters' ? [ outputParameter ] : undefined
+  };
+
+  const extensionElements = { get: key => key === 'values' ? [ ioMapping ] : undefined };
+
+  return {
+    id,
+    get: key => key === 'extensionElements' ? extensionElements : undefined
+  };
+}
+
+function flushDeferred() {
+  return new Promise(resolve => setTimeout(resolve, 0));
 }

--- a/lib/hooks/useElementNavigation.js
+++ b/lib/hooks/useElementNavigation.js
@@ -2,11 +2,18 @@ import { useCallback } from 'react';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import useService from './useService';
+import { getDefinitionPath } from '../utils/definitionPath';
 
-export default function useElementNavigation(businessObject) {
+export default function useElementNavigation(businessObject, options = {}) {
+  const { variableName } = options;
+
   const selection = useService('selection');
   const canvas = useService('canvas');
   const elementRegistry = useService('elementRegistry');
+  const eventBus = useService('eventBus');
+
+  // optional: without a properties panel we navigate without revealing
+  const propertiesPanel = useService('propertiesPanel', false);
 
   const selectedElements = selection.get();
   const isSelected = selectedElements.some(el => el.id === businessObject.id);
@@ -25,7 +32,41 @@ export default function useElementNavigation(businessObject) {
 
     canvas.scrollToElement(element);
     selection.select(element);
-  }, [ businessObject, selection, canvas, elementRegistry ]);
+
+    if (!variableName) {
+      return;
+    }
+
+    const entryId = resolveEntryId(propertiesPanel, element, getDefinitionPath(element, variableName));
+
+    if (!entryId) {
+      return;
+    }
+
+    // defer so the properties panel re-renders for the newly selected element
+    // (and its entries mount) before we ask it to reveal the entry
+    setTimeout(() => eventBus.fire('propertiesPanel.showEntry', { id: entryId }), 0);
+  }, [ businessObject, variableName, selection, canvas, elementRegistry, eventBus, propertiesPanel ]);
 
   return { isSelected, navigate };
+}
+
+/**
+ * Ask the properties panel which entry renders the given moddle path.
+ *
+ * Returns null when there is no panel, when it is too old to resolve paths, or
+ * when every provider defers - we then navigate without revealing.
+ *
+ * @param {Object} [propertiesPanel]
+ * @param {djs.model.Base} element
+ * @param {Array<string|number>|null} path
+ *
+ * @returns {string|null}
+ */
+function resolveEntryId(propertiesPanel, element, path) {
+  if (!path || !propertiesPanel || typeof propertiesPanel.getEntryId !== 'function') {
+    return null;
+  }
+
+  return propertiesPanel.getEntryId(element, path) || null;
 }

--- a/lib/utils/__test__/definition-path.xml
+++ b/lib/utils/__test__/definition-path.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.49.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="MappingTask" name="Mapping task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="worker" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=42" target="localInput" />
+          <zeebe:output source="=body.id" target="orderId" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_151k0wz</bpmn:incoming>
+      <bpmn:outgoing>Flow_09w32jp</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:scriptTask id="ScriptTask" name="&#34;scriptResult&#34; producer">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=1 + 1" resultVariable="scriptResult" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_09w32jp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ls9q3c</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:businessRuleTask id="DecisionTask" name="&#34;decisionResult&#34; producer">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="myDecision" resultVariable="decisionResult" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1ls9q3c</bpmn:incoming>
+      <bpmn:outgoing>Flow_1k7841u</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:serviceTask id="ExampleDataTask" name="&#34;exampleValue&#34; producer">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="camundaModeler:exampleOutputJson" value="{&#10;  &#34;exampleValue&#34;: 650&#10;}" />
+        </zeebe:properties>
+        <zeebe:taskDefinition type="worker2" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1k7841u</bpmn:incoming>
+      <bpmn:outgoing>Flow_0alkce0</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:startEvent id="Event_05mz1ca">
+      <bpmn:outgoing>Flow_151k0wz</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_151k0wz" sourceRef="Event_05mz1ca" targetRef="MappingTask" />
+    <bpmn:sequenceFlow id="Flow_09w32jp" sourceRef="MappingTask" targetRef="ScriptTask" />
+    <bpmn:sequenceFlow id="Flow_1ls9q3c" sourceRef="ScriptTask" targetRef="DecisionTask" />
+    <bpmn:sequenceFlow id="Flow_1k7841u" sourceRef="DecisionTask" targetRef="ExampleDataTask" />
+    <bpmn:endEvent id="Event_1ujq0gi">
+      <bpmn:incoming>Flow_0alkce0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0alkce0" sourceRef="ExampleDataTask" targetRef="Event_1ujq0gi" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="MappingTask_di" bpmnElement="MappingTask">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ScriptTask_di" bpmnElement="ScriptTask">
+        <dc:Bounds x="420" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DecisionTask_di" bpmnElement="DecisionTask">
+        <dc:Bounds x="580" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExampleDataTask_di" bpmnElement="ExampleDataTask">
+        <dc:Bounds x="740" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05mz1ca_di" bpmnElement="Event_05mz1ca">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ujq0gi_di" bpmnElement="Event_1ujq0gi">
+        <dc:Bounds x="882" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_151k0wz_di" bpmnElement="Flow_151k0wz">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09w32jp_di" bpmnElement="Flow_09w32jp">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="420" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ls9q3c_di" bpmnElement="Flow_1ls9q3c">
+        <di:waypoint x="520" y="120" />
+        <di:waypoint x="580" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k7841u_di" bpmnElement="Flow_1k7841u">
+        <di:waypoint x="680" y="120" />
+        <di:waypoint x="740" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0alkce0_di" bpmnElement="Flow_0alkce0">
+        <di:waypoint x="840" y="120" />
+        <di:waypoint x="882" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/lib/utils/__test__/definitionPath.integration.spec.js
+++ b/lib/utils/__test__/definitionPath.integration.spec.js
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// the source entry, not the pre-bundled dist: the dist ships its own copy of
+// bpmn-js-properties-panel, so it would resolve against a panel older than the
+// one this package is developed against
+import CamundaCloudModeler from 'camunda-bpmn-js/lib/camunda-cloud/Modeler';
+
+import { bootstrapBpmnJS, inject } from 'bpmn-js/test/helper';
+
+import diagramXML from './definition-path.xml?raw';
+import { getDefinitionPath } from '../definitionPath';
+
+
+// pins the derived paths to what the properties panel actually resolves them to,
+// so a change to either side fails here instead of silently revealing nothing
+describe('definitionPath - properties panel resolution', () => {
+
+  beforeEach(bootstrapBpmnJS(CamundaCloudModeler, diagramXML));
+
+
+  it('should resolve an output mapping target', inject((elementRegistry, propertiesPanel) => {
+
+    // given
+    const element = elementRegistry.get('MappingTask');
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, getDefinitionPath(element, 'orderId'));
+
+    // then
+    expect(entryId).to.eql('MappingTask-output-0-target');
+  }));
+
+
+  it('should resolve an input mapping target', inject((elementRegistry, propertiesPanel) => {
+
+    // given
+    const element = elementRegistry.get('MappingTask');
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, getDefinitionPath(element, 'localInput'));
+
+    // then
+    expect(entryId).to.eql('MappingTask-input-0-target');
+  }));
+
+
+  it('should resolve a script result variable', inject((elementRegistry, propertiesPanel) => {
+
+    // given
+    const element = elementRegistry.get('ScriptTask');
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, getDefinitionPath(element, 'scriptResult'));
+
+    // then
+    expect(entryId).to.eql('resultVariable');
+  }));
+
+
+  it('should resolve a called decision result variable', inject((elementRegistry, propertiesPanel) => {
+
+    // given
+    const element = elementRegistry.get('DecisionTask');
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, getDefinitionPath(element, 'decisionResult'));
+
+    // then
+    expect(entryId).to.eql('resultVariable');
+  }));
+
+
+  it('should resolve an example output property', inject((elementRegistry, propertiesPanel) => {
+
+    // given
+    const element = elementRegistry.get('ExampleDataTask');
+
+    // when
+    const entryId = propertiesPanel.getEntryId(element, getDefinitionPath(element, 'exampleValue'));
+
+    // then
+    expect(entryId).to.eql('ExampleDataTask-extensionProperty-0-value');
+  }));
+
+});

--- a/lib/utils/__test__/definitionPath.spec.js
+++ b/lib/utils/__test__/definitionPath.spec.js
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest';
+
+import { getDefinitionPath } from '../definitionPath';
+
+
+describe('definitionPath', () => {
+
+  describe('io mapping', () => {
+
+    it('should point at the output mapping target', () => {
+
+      // given
+      const bo = businessObject('Task_1', ioMapping({ outputs: [ 'foo', 'bar' ] }));
+
+      // when
+      const path = getDefinitionPath(bo, 'bar');
+
+      // then
+      expect(path).toEqual([ 'extensionElements', 'values', 0, 'outputParameters', 1, 'target' ]);
+    });
+
+
+    it('should point at the input mapping target when only an input matches', () => {
+
+      // given
+      const bo = businessObject('Task_1', ioMapping({ inputs: [ 'localVar' ] }));
+
+      // when
+      const path = getDefinitionPath(bo, 'localVar');
+
+      // then
+      expect(path).toEqual([ 'extensionElements', 'values', 0, 'inputParameters', 0, 'target' ]);
+    });
+
+
+    it('should prefer the output mapping over the input mapping', () => {
+
+      // given
+      const bo = businessObject('Task_1', ioMapping({ outputs: [ 'x' ], inputs: [ 'x' ] }));
+
+      // when
+      const path = getDefinitionPath(bo, 'x');
+
+      // then
+      expect(path).toEqual([ 'extensionElements', 'values', 0, 'outputParameters', 0, 'target' ]);
+    });
+
+
+    it('should return null when no mapping row matches', () => {
+
+      // given
+      const bo = businessObject('Task_1', ioMapping({ outputs: [ 'foo' ] }));
+
+      // when
+      const path = getDefinitionPath(bo, 'missing');
+
+      // then
+      expect(path).toBe(null);
+    });
+
+  });
+
+
+  describe('result variable', () => {
+
+    it('should point at the script result variable', () => {
+
+      // given
+      const bo = businessObject('Task_1', script('scriptResult'));
+
+      // when
+      const path = getDefinitionPath(bo, 'scriptResult');
+
+      // then
+      expect(path).toEqual([ 'extensionElements', 'values', 0, 'resultVariable' ]);
+    });
+
+
+    it('should point at the called decision result variable', () => {
+
+      // given
+      const bo = businessObject('Task_1', calledDecision('decisionResult'));
+
+      // when
+      const path = getDefinitionPath(bo, 'decisionResult');
+
+      // then
+      expect(path).toEqual([ 'extensionElements', 'values', 0, 'resultVariable' ]);
+    });
+
+
+    it('should return null when the result variable does not match', () => {
+
+      // given
+      const bo = businessObject('Task_1', script('scriptResult'));
+
+      // when
+      const path = getDefinitionPath(bo, 'other');
+
+      // then
+      expect(path).toBe(null);
+    });
+
+  });
+
+
+  describe('example output data', () => {
+
+    it('should point at the example output property value', () => {
+
+      // given
+      const bo = businessObject('Task_1', zeebeProperties({ expenseAmount: 650 }));
+
+      // when
+      const path = getDefinitionPath(bo, 'expenseAmount');
+
+      // then
+      expect(path).toEqual([ 'extensionElements', 'values', 0, 'properties', 0, 'value' ]);
+    });
+
+
+    it('should return null when the example output does not declare the variable', () => {
+
+      // given
+      const bo = businessObject('Task_1', zeebeProperties({ expenseAmount: 650 }));
+
+      // when
+      const path = getDefinitionPath(bo, 'other');
+
+      // then
+      expect(path).toBe(null);
+    });
+
+
+    it('should return null for a malformed example output', () => {
+
+      // given
+      const bo = businessObject('Task_1', zeebeProperties('{ not json'));
+
+      // when
+      const path = getDefinitionPath(bo, 'expenseAmount');
+
+      // then
+      expect(path).toBe(null);
+    });
+
+  });
+
+
+  describe('element resolution', () => {
+
+    it('should resolve the business object of a diagram element', () => {
+
+      // given
+      const bo = businessObject('Task_1', ioMapping({ outputs: [ 'foo' ] }));
+
+      // when
+      const path = getDefinitionPath({ id: 'Task_1', businessObject: bo }, 'foo');
+
+      // then
+      expect(path).toEqual([ 'extensionElements', 'values', 0, 'outputParameters', 0, 'target' ]);
+    });
+
+  });
+
+
+  describe('path indices', () => {
+
+    it('should index the extension element by its position', () => {
+
+      // given
+      const bo = businessObject('Task_1', taskDefinition(), ioMapping({ outputs: [ 'foo' ] }));
+
+      // when
+      const path = getDefinitionPath(bo, 'foo');
+
+      // then
+      expect(path).toEqual([ 'extensionElements', 'values', 1, 'outputParameters', 0, 'target' ]);
+    });
+
+
+    it('should index the example output property by its position', () => {
+
+      // given
+      const bo = businessObject('Task_1', zeebeProperties({ expenseAmount: 650 }, { leading: 'property' }));
+
+      // when
+      const path = getDefinitionPath(bo, 'expenseAmount');
+
+      // then
+      expect(path).toEqual([ 'extensionElements', 'values', 0, 'properties', 1, 'value' ]);
+    });
+
+  });
+
+
+  describe('no definition', () => {
+
+    it('should return null without extension elements', () => {
+
+      // given
+      const bo = businessObject('Task_1');
+
+      // when
+      const path = getDefinitionPath(bo, 'foo');
+
+      // then
+      expect(path).toBe(null);
+    });
+
+
+    it('should return null without a variable name', () => {
+
+      // given
+      const bo = businessObject('Task_1', ioMapping({ outputs: [ 'foo' ] }));
+
+      // when
+      const path = getDefinitionPath(bo, undefined);
+
+      // then
+      expect(path).toBe(null);
+    });
+
+  });
+
+});
+
+
+// helpers /////////////////////////
+
+function parameter(target) {
+  return { get: key => key === 'target' ? target : undefined };
+}
+
+function ioMapping({ outputs = [], inputs = [] }) {
+  return {
+    $type: 'zeebe:IoMapping',
+    get(key) {
+      if (key === 'outputParameters') return outputs.map(parameter);
+      if (key === 'inputParameters') return inputs.map(parameter);
+      return undefined;
+    }
+  };
+}
+
+function taskDefinition() {
+  return {
+    $type: 'zeebe:TaskDefinition',
+    get: key => key === 'type' ? 'worker' : undefined
+  };
+}
+
+function script(resultVariable) {
+  return {
+    $type: 'zeebe:Script',
+    get: key => key === 'resultVariable' ? resultVariable : undefined
+  };
+}
+
+function calledDecision(resultVariable) {
+  return {
+    $type: 'zeebe:CalledDecision',
+    get: key => key === 'resultVariable' ? resultVariable : undefined
+  };
+}
+
+function property(name, value) {
+  return {
+    get(key) {
+      if (key === 'name') return name;
+      if (key === 'value') return value;
+      return undefined;
+    }
+  };
+}
+
+function zeebeProperties(exampleOutput, ...leadingProperties) {
+  const value = typeof exampleOutput === 'string' ? exampleOutput : JSON.stringify(exampleOutput);
+
+  const properties = [
+    ...leadingProperties.map(leading => property('other', JSON.stringify(leading))),
+    property('camundaModeler:exampleOutputJson', value)
+  ];
+
+  return {
+    $type: 'zeebe:Properties',
+    get: key => key === 'properties' ? properties : undefined
+  };
+}
+
+function businessObject(id, ...extensions) {
+  const values = extensions.filter(Boolean);
+
+  const extensionElements = values.length
+    ? { get: key => key === 'values' ? values : undefined }
+    : null;
+
+  return {
+    id,
+    get: key => key === 'extensionElements' ? extensionElements : undefined
+  };
+}

--- a/lib/utils/definitionPath.js
+++ b/lib/utils/definitionPath.js
@@ -1,0 +1,127 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+const EXAMPLE_OUTPUT_JSON = 'camundaModeler:exampleOutputJson';
+
+const RESULT_VARIABLE_TYPES = [ 'zeebe:Script', 'zeebe:CalledDecision' ];
+
+// an output mapping publishes the variable into the surrounding scope while an
+// input only defines it locally, so an output is the definition we point at
+const IO_MAPPING_COLLECTIONS = [ 'outputParameters', 'inputParameters' ];
+
+/**
+ * Derive the moddle property path of the location that defines `variableName` on
+ * the given element - the same path shape bpmnlint rules report, and what
+ * `propertiesPanel.getEntryId(element, path)` resolves to a rendered entry.
+ *
+ * We report where a variable is defined, never which entry renders it: that is
+ * the properties panel's business, and only it knows that an element template
+ * replaced a standard field with a `custom-entry-*` one.
+ *
+ * Covers the ways a zeebe element produces a variable:
+ * - input/output mapping row → the row's `target`
+ * - script task / called decision → `resultVariable`
+ * - generated example data → the `camundaModeler:exampleOutputJson` value
+ *
+ * @param {djs.model.Base|ModdleElement} element - the producing element
+ * @param {string} variableName
+ *
+ * @returns {Array<string|number>|null} the path, relative to the element's
+ * business object, or null when nothing defines the variable
+ */
+export function getDefinitionPath(element, variableName) {
+  const businessObject = getBusinessObject(element);
+
+  if (!businessObject || !variableName) {
+    return null;
+  }
+
+  const values = getExtensionValues(businessObject);
+
+  return getIoMappingPath(values, variableName)
+    || getResultVariablePath(values, variableName)
+    || getExampleOutputPath(values, variableName);
+}
+
+function getIoMappingPath(values, variableName) {
+  const index = values.findIndex(value => value.$type === 'zeebe:IoMapping');
+
+  if (index === -1) {
+    return null;
+  }
+
+  for (const collection of IO_MAPPING_COLLECTIONS) {
+    const parameters = values[ index ].get(collection) || [];
+
+    const parameterIndex = parameters.findIndex(parameter => parameter.get('target') === variableName);
+
+    if (parameterIndex !== -1) {
+      return [ 'extensionElements', 'values', index, collection, parameterIndex, 'target' ];
+    }
+  }
+
+  return null;
+}
+
+function getResultVariablePath(values, variableName) {
+  const index = values.findIndex(value => RESULT_VARIABLE_TYPES.includes(value.$type)
+    && value.get('resultVariable') === variableName);
+
+  if (index === -1) {
+    return null;
+  }
+
+  return [ 'extensionElements', 'values', index, 'resultVariable' ];
+}
+
+function getExampleOutputPath(values, variableName) {
+  const index = values.findIndex(value => value.$type === 'zeebe:Properties');
+
+  if (index === -1) {
+    return null;
+  }
+
+  const properties = values[ index ].get('properties') || [];
+
+  const propertyIndex = properties.findIndex(property => property.get('name') === EXAMPLE_OUTPUT_JSON);
+
+  if (propertyIndex === -1 || !definesVariable(properties[ propertyIndex ].get('value'), variableName)) {
+    return null;
+  }
+
+  return [ 'extensionElements', 'values', index, 'properties', propertyIndex, 'value' ];
+}
+
+function getExtensionValues(businessObject) {
+  const extensionElements = businessObject.get('extensionElements');
+
+  if (!extensionElements) {
+    return [];
+  }
+
+  return extensionElements.get('values') || [];
+}
+
+/**
+ * Whether the given `camundaModeler:exampleOutputJson` value declares
+ * `variableName` as a top-level key.
+ *
+ * @param {string} value - the raw JSON string
+ * @param {string} variableName
+ *
+ * @returns {boolean}
+ */
+function definesVariable(value, variableName) {
+  let exampleOutput;
+
+  try {
+    exampleOutput = JSON.parse(value || '{}');
+  } catch {
+    return false;
+  }
+
+  if (!exampleOutput || typeof exampleOutput !== 'object') {
+    return false;
+  }
+
+  return Object.prototype.hasOwnProperty.call(exampleOutput, variableName);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@vitest/browser": "^4.1.8",
         "@vitest/browser-playwright": "^4.1.8",
         "bpmn-js": "^18.13.1",
+        "bpmn-js-properties-panel": "^5.63.0",
         "camunda-bpmn-js": "^5.25.0",
         "eslint": "^9.39.3",
         "eslint-plugin-bpmn-io": "^2.2.0",
@@ -404,14 +405,15 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.19.0.tgz",
-      "integrity": "sha512-wmxc3NvUkPr6XvsGCCRmKSX0lVqSq71n9qOU0IIJjPmNw9OrwelkADAOajxhOcrS/b8gRdHRsupS//zppBrEcA==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.25.0.tgz",
+      "integrity": "sha512-ESoxljIChKo4Nm5Ge+j66RBK30ei46EFjQ51EdXlAbyeWD8h7mK448ypH58TRT8CSvBBiOI/SCtpzFK46Mp+xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@camunda/element-templates-json-schema": "^0.21.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.37.0",
+        "@camunda/element-templates-json-schema": "^0.22.0",
+        "@camunda/zeebe-configuration-templates-json-schema": "^0.2.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.45.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^5.0.0"
       }
@@ -440,43 +442,30 @@
       }
     },
     "node_modules/@bpmn-io/feel-editor": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.5.2.tgz",
-      "integrity": "sha512-pxbhUDAlLe+zDAvmG7Y057o8rnVImKYEbgjH4+zZiq3WjPw5bZYu2kraJfpWMs3xkyOCvLR6H3J3f8yJRuHmgw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.6.0.tgz",
+      "integrity": "sha512-rI7vFBATeKJVi/KpkfxnclTObAvQGYda0l5eKhNwGIJ8D3+aPQlgdNtxJATX1keXVkqsA1Q/+Yn8Ih+dnC0NMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^3.1.0",
-        "@bpmn-io/lang-feel": "^3.0.0",
-        "@camunda/feel-builtins": "^1.0.0",
+        "@bpmn-io/lang-feel": "^4.0.2",
+        "@camunda/feel-builtins": "^1.2.0",
         "@codemirror/autocomplete": "^6.20.0",
-        "@codemirror/commands": "^6.10.2",
+        "@codemirror/commands": "^6.10.3",
         "@codemirror/language": "^6.11.3",
-        "@codemirror/lint": "^6.9.3",
-        "@codemirror/state": "^6.5.4",
-        "@codemirror/view": "^6.39.13",
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.43.1",
         "@lezer/highlight": "^1.2.3",
-        "min-dom": "^5.2.0",
+        "min-dom": "^5.3.0",
         "mitt": "^3.0.1"
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/@bpmn-io/feel-editor/node_modules/@bpmn-io/lang-feel": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-3.0.0.tgz",
-      "integrity": "sha512-t/k0z5AW18J7Qz2i/bIFAlvlcS63RuyQB9OQ0YiC1WyMosxXRAnv98LHnVbwirx9vje1DLll85tkBT2B8KLjmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bpmn-io/lezer-feel": "^2.0.0",
-        "@codemirror/autocomplete": "^6.20.0",
-        "@codemirror/language": "^6.11.3",
-        "@lezer/common": "^1.4.0"
       },
-      "engines": {
-        "node": ">= 20.12.0"
+      "peerDependencies": {
+        "@bpmn-io/cm-theme": "^0.2.0"
       }
     },
     "node_modules/@bpmn-io/feel-lint": {
@@ -493,31 +482,52 @@
         "node": "*"
       }
     },
-    "node_modules/@bpmn-io/feelin": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feelin/-/feelin-6.1.0.tgz",
-      "integrity": "sha512-nqmmlHRD9tl0ZcpYTEkZdpc/rAMoYc+ct0SOg9fFIFWRaEApme3DuXC7v9AMA5g+upGCKd6cUc3t97y+unpfMw==",
+    "node_modules/@bpmn-io/feelers-editor": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feelers-editor/-/feelers-editor-1.1.1.tgz",
+      "integrity": "sha512-HNvssf1nb/OohOgFxxR0hWIpIb8JBvmr2CQ28GD/5WLPKe3uvu9mpItIjNTCpLxLuVHlsJLNDtLkf2B6tvmt9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/lezer-feel": "^2.1.0",
-        "@lezer/common": "^1.5.0",
-        "luxon": "^3.7.2",
-        "min-dash": "^5.0.0"
+        "@bpmn-io/feelers-lint": "^1.0.0",
+        "@bpmn-io/lang-feelers": "^1.0.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.1",
+        "@codemirror/language": "^6.12.1",
+        "@codemirror/lint": "^6.9.3",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.12",
+        "@lezer/common": "^1.5.1",
+        "@lezer/html": "^1.3.13",
+        "@lezer/markdown": "^1.6.3",
+        "min-dom": "^5.2.0",
+        "mitt": "^3.0.1"
       },
-      "engines": {
-        "node": ">= 20.12.0"
+      "peerDependencies": {
+        "@bpmn-io/cm-theme": "^0.2.1"
+      }
+    },
+    "node_modules/@bpmn-io/feelers-lint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feelers-lint/-/feelers-lint-1.0.0.tgz",
+      "integrity": "sha512-9McPCub8NBSD3gbAM9fu6laGVvb6U/D8Y5Ar/GGvOaAuJ6W34yP5jaV/on4MALTwmmXTDadZjO2RJJNub3JmwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/feel-lint": "^3.1.0",
+        "@codemirror/language": "^6.12.1",
+        "@codemirror/lint": "^6.9.3"
       }
     },
     "node_modules/@bpmn-io/lang-feel": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-4.0.0.tgz",
-      "integrity": "sha512-QzeIJ4fSSPIqGMSiW/FM/Pv+rP+kKO+6DtndNQYWO3EzmhNOy4IM3S9HKlTmjPHWw6Yj2FJhYE5tTavA7tfZQQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-4.0.2.tgz",
+      "integrity": "sha512-rTPeJ77/2nYKbJXpvDmrNXy+opoIpD3Rsch0grCUZAO6xF68r41QeV8SqOdr2yZxD/4gI6YXlQhqh4rqFRDJXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/lezer-feel": "^3.0.0",
-        "@codemirror/autocomplete": "^6.20.1",
+        "@bpmn-io/lezer-feel": "^3.0.1",
+        "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/language": "^6.12.3",
         "@lezer/common": "^1.5.2"
       },
@@ -526,6 +536,34 @@
       }
     },
     "node_modules/@bpmn-io/lang-feel/node_modules/@bpmn-io/lezer-feel": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-3.0.1.tgz",
+      "integrity": "sha512-+wWg4DP2h8WOEQx2Bz51blsw9dCqKj3kIDKYccABuoAEhzZeDhmm0A2k4ANmm9lf0w5pJmVSYz2djtrbzOvzzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.10",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/lang-feelers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feelers/-/lang-feelers-1.0.0.tgz",
+      "integrity": "sha512-VgBDw9cXr62e6Qs6LixQyLiBxxv7Kh8fxKFkYCmHPf/cO8beLQGjnF789wRlhK05yh/CuHi7oN7EYChrFQOHwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^3.0.0",
+        "@bpmn-io/lezer-feelers": "^1.0.0",
+        "@codemirror/language": "^6.12.1",
+        "@lezer/common": "^1.5.1"
+      }
+    },
+    "node_modules/@bpmn-io/lang-feelers/node_modules/@bpmn-io/lezer-feel": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-3.0.1.tgz",
       "integrity": "sha512-+wWg4DP2h8WOEQx2Bz51blsw9dCqKj3kIDKYccABuoAEhzZeDhmm0A2k4ANmm9lf0w5pJmVSYz2djtrbzOvzzA==",
@@ -555,6 +593,18 @@
         "node": ">= 20.12.0"
       }
     },
+    "node_modules/@bpmn-io/lezer-feelers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feelers/-/lezer-feelers-1.0.0.tgz",
+      "integrity": "sha512-P0znH2SY85O7RmOr/FgveFiTREet9DSCf3nH3J/StkI5i7Q384o+GEeTmv58n91FlUknS20KE3T8Yk5Qmab+hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.1",
+        "@lezer/highlight": "^1.1.6",
+        "@lezer/lr": "^1.4.8"
+      }
+    },
     "node_modules/@bpmn-io/moddle-utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-utils/-/moddle-utils-0.3.0.tgz",
@@ -566,23 +616,51 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.40.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.40.3.tgz",
-      "integrity": "sha512-+aU75w4Dhhz8zgy02467tKBSylA9SF2zMJm7MP/vDu3M0y287dLEUjZTeYhwHgassEglWJB7dikeLhGvxNCMQA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.47.0.tgz",
+      "integrity": "sha512-tZQRM0x9KLUEFU2FyHCwnYjSq1lbxpY8oCwABFA00IcuyeEDQFDV5DFg7ytTv2qOyWgncZ2xNXPRQ9pydkN2gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/feel-editor": "^2.5.0",
-        "@carbon/icons": "^11.69.0",
+        "@bpmn-io/feel-editor": "^2.6.0",
+        "@bpmn-io/feelers-editor": "^1.0.0",
+        "@codemirror/autocomplete": "^6.18.6",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/language": "^6.11.0",
+        "@codemirror/lint": "^6.9.5",
+        "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.28.1",
         "classnames": "^2.5.1",
-        "feelers": "^1.5.1",
         "focus-trap": "^8.0.0",
         "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0"
+        "min-dom": "^5.3.0"
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@bpmn-io/semver-compat": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/semver-compat/-/semver-compat-0.1.0.tgz",
+      "integrity": "sha512-hIcW42Ku92MUioL6aknDbRoW1jK8ZEqIe8qZZ+d3cjitDO+PMEFFXj/sezJYIHMe8elu4CBz9qpjkV8WIVG9qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.2"
+      }
+    },
+    "node_modules/@bpmn-io/semver-compat/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@bpmn-io/svg-to-image": {
@@ -614,9 +692,9 @@
       }
     },
     "node_modules/@camunda/element-templates-json-schema": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.21.0.tgz",
-      "integrity": "sha512-3O5oovVIsCrU0tG+WMm6rcmtiGM7tYni/H+oPN1EqLG1B3HPcRiLwypNrHz1w6aQy6vnjB8ovzSJ42taapqN/w==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.22.0.tgz",
+      "integrity": "sha512-fknIeRvnej9CpJvSHsQm9VhxcruxmdRI8IZGh2bth0qiZZLNAwQpSF139m1H//Fz/nmP/VpHwI0Tbhqh3JK9aA==",
       "dev": true,
       "license": "MIT"
     },
@@ -638,16 +716,23 @@
       }
     },
     "node_modules/@camunda/feel-builtins": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.0.0.tgz",
-      "integrity": "sha512-/0w86UVmNcNqlZB9n/4Ro5wqHt+JuBKwD8kt+O7ASxSqs80D1y4BMfgu+We+O7cA8MWbt9eNKUjwRgGf4f75TQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.4.0.tgz",
+      "integrity": "sha512-G3jH5MRvF/3L9/h6fY1zn+kwgYgH7APa84p34jajSG9IVWPCIGpttVGyRTrnbsCI76C2QdPbR2AvOm3RaLzUJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@camunda/zeebe-configuration-templates-json-schema": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-configuration-templates-json-schema/-/zeebe-configuration-templates-json-schema-0.2.0.tgz",
+      "integrity": "sha512-H/ej903ai3dGDuZqYsr9pbCbkoseztoGvjo22Op+Ac8ZO3iS0pk38+I8DCqdtC80mQ7WAI7ZzHsv7hU1XLMyNA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.37.0.tgz",
-      "integrity": "sha512-wZcsplDWjRx8cL2BiLE53DIqz/J2BDpkkWQR/eAWg78dKLfgq8kVG2/xeePyHJ8dmkb2WzdZCB102JSkStzi6Q==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.45.0.tgz",
+      "integrity": "sha512-cfh0PjqggGVbdlfg/qYi1NCL+rNnIe7UQA4Ku1MVFoCV1Bo/r6ijivRw1kx/2VJpMBfvvEOUnhuR/Azed3rdPg==",
       "dev": true,
       "license": "MIT"
     },
@@ -683,17 +768,6 @@
       "version": "10.74.0",
       "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.74.0.tgz",
       "integrity": "sha512-3i498EDg7fG8uLTd38gXckKUiPOSpOLKuSvdvedZs5TCIAc9HLpsx3aQithvZ3zhggKeMFFX/k6aBemZb6i7vA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.5.0"
-      }
-    },
-    "node_modules/@carbon/icons": {
-      "version": "11.76.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.76.0.tgz",
-      "integrity": "sha512-e9XnUWPgxsyvgCL/ti/Ee2fItqRs/WrHkwy7GPqbEGdGZKSd9pBvO+jN7nxBT5TLdA50q26t5hR0U2taEyc5Kg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -818,9 +892,9 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
-      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -831,16 +905,27 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
-      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.4.0",
+        "@codemirror/state": "^6.7.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
       }
     },
     "node_modules/@codemirror/language": {
@@ -858,33 +943,33 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.9.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
-      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.35.0",
+        "@codemirror/view": "^6.42.0",
         "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
-      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.39.16",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.16.tgz",
-      "integrity": "sha512-m6S22fFpKtOWhq8HuhzsI1WzUP/hB9THbDj0Tl5KX4gbO6Y91hwBl7Yky33NdvB6IffuRFiBxf1R8kJMyXmA4Q==",
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/state": "^6.5.0",
+        "@codemirror/state": "^6.7.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
@@ -1656,6 +1741,30 @@
         "@lezer/common": "^1.3.0"
       }
     },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/lr": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
@@ -1666,9 +1775,9 @@
       }
     },
     "node_modules/@lezer/markdown": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
-      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.7.2.tgz",
+      "integrity": "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2817,7 +2926,6 @@
       "integrity": "sha512-+RY54S8OuVvg94THpneQvFRmqWdAHeqtMzgMW6JNurHxe8rsS07cHQdfGkXnTUXiBcyZ0j3SiDIxxj0RPiqCkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -3024,46 +3132,34 @@
       }
     },
     "node_modules/bpmn-js-element-templates": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.22.0.tgz",
-      "integrity": "sha512-GGK/V1Wma8gopIMnsvQEu2Mev55zG9lN2p01awaGFrVGOCWQgx0uVNvlZfG4xpCKbeLrskrSCjKWgkV4xdqOKg==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.29.0.tgz",
+      "integrity": "sha512-Ee4/aLhZtvykS1pDYS9iRA5TE4jtkY/ODfn5vcouUYb7lWnnBjbVjVHf4l2b1/v+PWNBqxHhz/1HbEJJr1SH7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.19.0",
+        "@bpmn-io/element-templates-validator": "^2.25.0",
         "@bpmn-io/extract-process-variables": "^2.2.1",
-        "bpmnlint": "^11.12.0",
+        "@bpmn-io/moddle-utils": "^0.3.0",
+        "@bpmn-io/semver-compat": "^0.1.0",
+        "bpmnlint": "^11.12.1",
         "classnames": "^2.5.1",
         "ids": "^3.0.0",
         "min-dash": "^5.0.0",
         "min-dom": "^5.3.0",
         "preact-markup": "^2.1.1",
-        "semver": "^7.7.4",
         "semver-compare": "^1.0.0",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.1"
       },
       "engines": {
         "node": "*"
       },
       "peerDependencies": {
-        "@bpmn-io/properties-panel": ">= 2.2",
+        "@bpmn-io/properties-panel": ">= 3.41.3",
         "bpmn-js": ">= 11.5",
         "bpmn-js-properties-panel": ">= 2",
         "camunda-bpmn-js-behaviors": ">= 1.2.1",
         "diagram-js": ">= 11.9"
-      }
-    },
-    "node_modules/bpmn-js-element-templates/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/bpmn-js-executable-fix": {
@@ -3076,16 +3172,15 @@
       }
     },
     "node_modules/bpmn-js-properties-panel": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.53.0.tgz",
-      "integrity": "sha512-fXn9yU6YLgr5SiaGHegAHZQe1jbezFPyqzZvTrTR1zOEmlNdTK4H9MAHFeBX6iasw31M9Y6KbPPP/tiZ/VhYug==",
+      "version": "5.63.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.63.0.tgz",
+      "integrity": "sha512-QVwqVyRsEEHh24jNoYz6wyHFHAxBz03zMP/RrO2Z3NnNH0wUYqC+rPux7PXzNcK0QM58oHb330OfuPBN4VMDCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bpmn-io/extract-process-variables": "^2.2.1",
         "array-move": "^4.0.0",
-        "ids": "^3.0.1",
+        "ids": "^3.0.2",
         "min-dash": "^5.0.0",
         "min-dom": "^5.3.0"
       },
@@ -3093,7 +3188,7 @@
         "node": "*"
       },
       "peerDependencies": {
-        "@bpmn-io/properties-panel": ">= 3.40",
+        "@bpmn-io/properties-panel": ">= 3.42.0",
         "bpmn-js": ">= 11.5",
         "camunda-bpmn-js-behaviors": ">= 0.4",
         "diagram-js": ">= 11.9"
@@ -3125,9 +3220,9 @@
       }
     },
     "node_modules/bpmnlint": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.12.0.tgz",
-      "integrity": "sha512-c8zXfG2YH3U06u1+T1uSkcd82ict27G2z7gAK5toJnfwIlhwCKCy0GxeqCk4z/reuk3Ja//x7Z04IKwNpn1sNQ==",
+      "version": "11.12.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.12.1.tgz",
+      "integrity": "sha512-s/V68yzJU/ko7ea6ljp/xUUC8PUN+fzZaqI+votu0DPzDc6OqvpBcKzw7rMpqS4WPw/HOW3cLw/C2poWilClCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4562,55 +4657,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/feelers": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/feelers/-/feelers-1.5.1.tgz",
-      "integrity": "sha512-LKIAqtScSfy55Tw62DhBcxIT3k2XnppzWrkmGfsbdad0a+TxMfaLF1CSYhoVRF5FvPAUXvor1Ux/75wtBaDYpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
-        "@bpmn-io/feel-lint": "^3.1.0",
-        "@bpmn-io/feelin": "^6.1.0",
-        "@bpmn-io/lezer-feel": "^2.1.0",
-        "@codemirror/autocomplete": "^6.20.0",
-        "@codemirror/commands": "^6.10.1",
-        "@codemirror/language": "^6.12.1",
-        "@codemirror/lint": "^6.9.3",
-        "@codemirror/state": "^6.5.4",
-        "@codemirror/view": "^6.39.12",
-        "@lezer/common": "^1.5.1",
-        "@lezer/highlight": "^1.1.6",
-        "@lezer/lr": "^1.4.8",
-        "@lezer/markdown": "^1.6.3",
-        "min-dom": "^5.2.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "workspaces": {
-        "packages": [
-          "feelers-playground"
-        ]
-      }
-    },
-    "node_modules/feelers/node_modules/@bpmn-io/cm-theme": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.3.1",
-        "@codemirror/view": "^6.5.1",
-        "@lezer/highlight": "^1.1.4"
-      },
-      "workspaces": {
-        "packages": [
-          "preview-themes"
-        ]
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5713,16 +5759,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -7581,9 +7617,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@vitest/browser": "^4.1.8",
     "@vitest/browser-playwright": "^4.1.8",
     "bpmn-js": "^18.13.1",
+    "bpmn-js-properties-panel": "^5.63.0",
     "camunda-bpmn-js": "^5.25.0",
     "eslint": "^9.39.3",
     "eslint-plugin-bpmn-io": "^2.2.0",

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -28,6 +28,12 @@ export default defineConfig({
     },
     sourcemap: true,
   },
+
+  // pre-bundle the modeler entry the integration specs bootstrap, so a cold run
+  // does not optimize it mid-test and reload
+  optimizeDeps: {
+    include: [ 'camunda-bpmn-js/lib/camunda-cloud/Modeler' ]
+  },
   test: {
     globals: true,
     browser: {


### PR DESCRIPTION
### Proposed Changes

This pull request aims to introduce a feature to help user navigate to the definition entry of the variable when navigating to the writer element.

The feature is not supported for the read variables as they can be read/consumed/used in multiple entries in the same element.

https://github.com/user-attachments/assets/37b30d8c-168c-4140-aed6-6bdc870ffc71


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
