### PR TITLE
fix: prevent filter input border from blinking on blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [@bpmn-io/variable-outline](https://github.com/bpmn-i
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: prevent filter input border from blinking on blur ([#105](https://github.com/bpmn-io/variable-outline/pull/105))
+
 ## 3.3.0
 
 * `FEAT`: reveal the field defining a variable when navigating to its writer ([#100](https://github.com/bpmn-io/variable-outline/pull/100))

--- a/lib/components/Search/Search.scss
+++ b/lib/components/Search/Search.scss
@@ -22,6 +22,11 @@
     background-color: var(--input-background-color, white);
     font-size: var(--text-size-base, 14px);
 
+    // focus shows as border + background; keep CDS's outline transparent rather
+    // than `none`, which its `outline` transition animates into a blink on blur
+    outline: 2px solid transparent;
+    outline-offset: -2px;
+
     &::placeholder {
       color: var(--placeholder-color, hsl(225, 10%, 35%));
     }
@@ -29,7 +34,6 @@
     &:focus {
       border-color: var(--input-focus-border-color, hsl(205, 100%, 50%));
       background-color: var(--input-focus-background-color, hsl(205, 100%, 95%));
-      outline: none;
     }
   }
 

--- a/lib/components/Search/__test__/Search.spec.jsx
+++ b/lib/components/Search/__test__/Search.spec.jsx
@@ -4,6 +4,9 @@ import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import CamundaCloudModeler from 'camunda-bpmn-js/dist/camunda-cloud-modeler.development.js';
 import { bootstrapBpmnJS, inject } from 'bpmn-js/test/helper';
 
+// the host application provides CDS styles; the outline assertions need them
+import '@carbon/styles/css/styles.css';
+
 import diagramXML from '../../../hooks/__test__/diagram.xml?raw';
 import { FilterProvider } from '../../../context/FilterContext';
 import { InjectorContext } from '../../../context/InjectorContext';
@@ -48,6 +51,68 @@ describe('lib/components/Search', function() {
     await waitFor(() => {
       expect(filterRef.current.search).to.eql('MySearch');
     });
+  }));
+
+});
+
+
+describe('lib/components/Search - focus styles', function() {
+
+  beforeEach(bootstrapModeler(diagramXML));
+
+
+  it('should not paint an outline when focused', inject(function(injector) {
+
+    // given
+    const { getByRole } = render(<TabContentStub />, { wrapper: createWrapper(injector) });
+
+    const searchInput = getByRole('searchbox');
+
+    // when
+    act(() => {
+      searchInput.focus();
+    });
+
+    // then
+    expect(getOutline(searchInput).outlineColor).to.eql(TRANSPARENT);
+  }));
+
+
+  it('should not change the outline on focus', inject(function(injector) {
+
+    // given
+    const { getByRole } = render(<TabContentStub />, { wrapper: createWrapper(injector) });
+
+    const searchInput = getByRole('searchbox');
+
+    const unfocused = getOutline(searchInput);
+
+    // when
+    act(() => {
+      searchInput.focus();
+    });
+
+    // then
+    expect(getOutline(searchInput)).to.eql(unfocused);
+  }));
+
+
+  it('should indicate focus via border', inject(function(injector) {
+
+    // given
+    const { getByRole } = render(<TabContentStub />, { wrapper: createWrapper(injector) });
+
+    const searchInput = getByRole('searchbox');
+
+    const unfocused = getComputedStyle(searchInput).borderColor;
+
+    // when
+    act(() => {
+      searchInput.focus();
+    });
+
+    // then
+    expect(getComputedStyle(searchInput).borderColor).not.to.eql(unfocused);
   }));
 
 });
@@ -190,6 +255,25 @@ describe('lib/components/Search - tracking', function() {
 
 
 // helpers /////////////////////////
+
+const TRANSPARENT = 'rgba(0, 0, 0, 0)';
+
+function TabContentStub() {
+  return <div className="bio-vo-tab-content">
+    <Search />
+  </div>;
+}
+
+function getOutline(element) {
+  const {
+    outlineColor,
+    outlineOffset,
+    outlineStyle,
+    outlineWidth
+  } = getComputedStyle(element);
+
+  return { outlineColor, outlineOffset, outlineStyle, outlineWidth };
+}
 
 function SearchWithFilter({ filterRef }) {
   const filter = useFilter();


### PR DESCRIPTION
Keep the CDS outline geometry in both states and only make it transparent. `outline: none` on focus also reset `outline-color`, so blurring animated a text-colored outline to transparent while `outline-style` snapped back to `solid`.

Related to camunda/camunda-modeler#5963

**Before**

https://github.com/user-attachments/assets/2cb0148c-1204-4899-b620-c2c0eccbfdb1

**After**

https://github.com/user-attachments/assets/63f79cfb-ccfe-48cb-9731-0f312444efb5

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
