### PR TITLE
fix(Scope): render scope badge as non-interactive span

### DIFF
--- a/lib/components/Scope/Scope.jsx
+++ b/lib/components/Scope/Scope.jsx
@@ -1,5 +1,4 @@
 import { ChevronRight } from '@carbon/icons-react';
-import { Tag } from '@carbon/react';
 
 import VariableRow from '../VariableRow';
 import { getSVGComponent } from '../BpmnIcon';
@@ -54,13 +53,11 @@ export default function Scope({ scopeName, scope, variables, defaultExpanded = t
 
         { ScopeIcon && <ScopeIcon className="variable-section-scope-icon" /> }
         <span className="variable-section-name">{ scopeName }</span>
-        <Tag
-          className="variable-scope-chip"
-          type={ scopeType === 'local' ? 'blue' : 'outline' }
-          size="sm"
+        <span
+          className={ `variable-scope-chip${scopeType === 'local' ? ' variable-scope-chip--local' : ''}` }
         >
           { scopeType === 'root' ? 'Root' : scopeType === 'local' ? 'Local' : 'Parent' }
-        </Tag>
+        </span>
         <span className="variable-section-count">{ variables.length }</span>
       </button>
 

--- a/lib/components/Scope/__test__/Scope.spec.jsx
+++ b/lib/components/Scope/__test__/Scope.spec.jsx
@@ -123,6 +123,88 @@ describe('#Scope variable expansion', () => {
 });
 
 
+describe('#Scope section header toggling', () => {
+
+  beforeEach(bootstrapModeler(diagramXML));
+
+  it('should render the section header as a native button', inject(async (injector, variableResolver, selection) => {
+
+    // given
+    const { availableVariables } = await getVariables({ variableResolver, selection, filter: defaultFilter });
+    const scope = availableVariables[0].scope;
+
+    const { container } = render(
+      <Scope
+        scopeName="TestScope"
+        scope={ scope }
+        variables={ availableVariables }
+        defaultExpanded={ false }
+      />,
+      { wrapper: createWrapper(injector, vi.fn()) }
+    );
+
+    // then
+    const header = container.querySelector('.variable-section-header');
+
+    expect(header.tagName).toBe('BUTTON');
+  }));
+
+
+  it('should not nest an interactive element inside the header button', inject(async (injector, variableResolver, selection) => {
+
+    // given
+    const { availableVariables } = await getVariables({ variableResolver, selection, filter: defaultFilter });
+    const scope = availableVariables[0].scope;
+
+    const { container } = render(
+      <Scope
+        scopeName="TestScope"
+        scope={ scope }
+        variables={ availableVariables }
+        defaultExpanded={ false }
+      />,
+      { wrapper: createWrapper(injector, vi.fn()) }
+    );
+
+    const header = container.querySelector('.variable-section-header');
+
+    // then - the scope chip must not introduce a nested button (Carbon Tag would)
+    expect(header.querySelector('button')).toBeNull();
+    expect(header.querySelector('[role="button"]')).toBeNull();
+  }));
+
+
+  it('should toggle expanded state on click', inject(async (injector, variableResolver, selection) => {
+
+    // given
+    const { availableVariables } = await getVariables({ variableResolver, selection, filter: defaultFilter });
+    const scope = availableVariables[0].scope;
+
+    const { container } = render(
+      <Scope
+        scopeName="TestScope"
+        scope={ scope }
+        variables={ availableVariables }
+        defaultExpanded={ true }
+      />,
+      { wrapper: createWrapper(injector, vi.fn()) }
+    );
+
+    const header = container.querySelector('.variable-section-header');
+
+    // assume
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+
+    // when
+    await act(() => { fireEvent.click(header); });
+
+    // then
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+  }));
+
+});
+
+
 // helpers /////////////////////////
 
 function bootstrapModeler(diagram, options) {

--- a/lib/components/outline-variables.scss
+++ b/lib/components/outline-variables.scss
@@ -97,25 +97,30 @@
   font-size: var(--text-size-small);
 }
 
-// specificity is important; otherwise CDS styles override
-.variable-scope-chip:not(.cds--tag--operational):not(span):not([disabled]) {
-  margin: 0;
+// non-interactive scope badge; intentionally not a Carbon <Tag>, whose
+// truncation tooltip would render a <button> nested inside the header button
+.variable-scope-chip {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-block-size: 18px;
+  min-inline-size: 32px;
+  max-inline-size: 208px;
+  padding: 0 8px;
+  border-radius: 16px;
+  font-size: 12px;
+  line-height: 16px;
+  letter-spacing: 0.32px;
+  font-weight: 400;
+  white-space: nowrap;
+  background-color: transparent;
+  outline: 1px solid var(--bio-vo-text-muted);
+  color: var(--bio-vo-text-muted);
 
-  &.cds--tag--outline {
-    background-color: transparent;
-    outline: 1px solid var(--bio-vo-text-muted);
-    color: var(--bio-vo-text-muted);
-  }
-
-  &.cds--tag.cds--tag--blue {
-    background-color: transparent;
-    outline: 1px solid var(--cds-tag-color-blue, #0043ce);
+  &--local {
+    outline-color: var(--cds-tag-color-blue, #0043ce);
     color: var(--cds-tag-color-blue, #0043ce);
-
-    .cds--tag__label {
-      color: var(--cds-tag-color-blue, #0043ce);
-      background: transparent;
-    }
   }
 }
 


### PR DESCRIPTION
### Proposed Changes

Render the scope section header's badge ("Root"/"Local"/"Parent") as a plain, non-interactive `<span>` instead of a Carbon `<Tag>`, keeping the header a native `<button>`. Before this PR Carbon would render a `<button>` inside of our `<button>`, breaking with HTML conventions and surfacing a React development in downstream consumers. 

**Root cause.** The section header is a native `<button>`. Its badge used a Carbon `<Tag>`, which measures its own label and—when the text is truncated—wraps it in a `DefinitionTooltip` whose trigger is a nested `<button class="cds--definition-term">`. A `<button>` inside the header `<button>` is invalid DOM nesting and triggers a React 19 hydration warning: _"In HTML, `<button>` cannot be a descendant of `<button>`."_

The badge is a static, non-interactive label, so a full Carbon `Tag` (with truncation detection and tooltip machinery) is the wrong tool. Replacing it with a plain span removes the nested interactive element at its source, rather than working around it (e.g. by turning the header into a `div[role="button"]`).

Changes:

* `Scope.jsx` — badge is now a `<span className="variable-scope-chip">`; dropped the `@carbon/react` `Tag` import. Header stays a semantic native `<button>`.
* `outline-variables.scss` — self-contained `.variable-scope-chip` styling matching Carbon's small tag (18px min-height, 16px radius, 8px padding, `label-01` type) and keeping the outline/blue colors. Visually identical, decoupled from Carbon `Tag` internals.
* `Scope.spec.jsx` — assert the header is a `<button>`, contains no nested `button`/`[role="button"]`, and toggles `aria-expanded` on click.

Steps to try out: open the variable outline, expand a scope with multiple levels, and confirm the "Root"/"Local"/"Parent" badges render unchanged and no React DOM-nesting warning appears in the console.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)